### PR TITLE
Fix Python requirement

### DIFF
--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -8,6 +8,21 @@ fi
 PACKAGES_PATH=${1}
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 TMP_DIR_NAME="tmp"
+PYTHON_BIN=${PYTHON_BIN:-python3}
+
+# check if PYTHON_BIN binary is availble
+if ! command -v ${PYTHON_BIN} > /dev/null; then
+    echo "Error: Cannot find ${PYTHON_BIN} binary."
+    exit 1
+fi
+python_bin=$(command -v ${PYTHON_BIN})
+
+# check if python version meets our requirements
+IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
+if [ ${python_version[0]} -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 6 ]]; then
+    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.6 or higher."
+    exit 1
+fi
 
 tmp_dir_path="${SCRIPT_DIR}/${TMP_DIR_NAME}"
 
@@ -24,7 +39,7 @@ for pkg in ${package_list}; do
     mkdir ${tmp_dir_path}
     unzip ${pkg} -d ${tmp_dir_path}
     pkg_dir_path=${tmp_dir_path}/${pkg_dir_name}
-    python ${SCRIPT_DIR}/python/run_tests.py -p ${pkg_dir_path} -v ${blender_version}
+    ${python_bin} ${SCRIPT_DIR}/python/run_tests.py -p ${pkg_dir_path} -v ${blender_version}
     if [ $? -ne 0 ]; then
         echo "Test Failure. (${pkg})"
         exit 1


### PR DESCRIPTION
[The first commit](https://github.com/nutti/fake-bpy-module/commit/0ff9cad9690688ca753f2df9c80b139cbdb1636e) adds python checks to the shell scripts so you don't run weird behaviour.


~[The second commit](https://github.com/nutti/fake-bpy-module/commit/804acaa518741a0906c3c52f11c3d16d12a687b5) increases the python version to 3.7, as apparently your code is not compatible with python3.6.9:~
https://github.com/nutti/fake-bpy-module/blob/a08ae2ecf74c29fef8b4d64bdfb55acec4518820/src/gen.py#L10

EDIT: Second commit does not seem to be needed with the `typing` python module on python 3.6.