### PR TITLE
Fix: replace bash with env bash and use errexit

### DIFF
--- a/src/gen_module.sh
+++ b/src/gen_module.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -eEu
 
 TMP_DIR_NAME=gen_module-tmp
 SCRIPT_DIR=$(cd $(dirname $0); pwd)

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -eEu
 
 if [ $# -ne 1 ]; then
     echo "Usage: run_tests.sh <packages_path>"

--- a/tools/pip_package/build_pip_package.sh
+++ b/tools/pip_package/build_pip_package.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # require: bash version >= 4
 # usage example: bash batch_gen_modules.sh 2.79 out
+set -eEu
 
 SUPPORTED_VERSIONS=(
     "2.78" "2.79" "2.80" "2.81" "2.82" "2.83"

--- a/tools/pip_package/publish_to_pypi.sh
+++ b/tools/pip_package/publish_to_pypi.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -eEu
 
 RELEASE_FILE="all.tar.gz"
 RELEASE_DIR="./release"

--- a/tools/utils/download_blender.sh
+++ b/tools/utils/download_blender.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # require: bash version >= 4
 # usage example: bash download_blender.sh 2.79 out
+set -eEu
 
 SUPPORTED_VERSIONS=(
     "2.78" "2.79" "2.80" "2.81" "2.82" "2.83"


### PR DESCRIPTION
**Purpose of the pull request**  
Making scripts end early if an error occurs, and do not continue silently.

**Description about the pull request**  
Using bash built ins to help in the process.
Also using `/usr/bin/env bash` in the shebang to be compatible with other Linux distro (e.g. [NixOS](https://nixos.org/)).
