### PR TITLE
Add: check if RELEASE_VERSION is PEP440 compatible

### DIFF
--- a/tools/pip_package/build_pip_package.sh
+++ b/tools/pip_package/build_pip_package.sh
@@ -55,6 +55,13 @@ else
     release_version="${RELEASE_VERSION}"
 fi
 
+# Verify that the version is compatible with PEP 440: https://www.python.org/dev/peps/pep-0440/
+# This is assumed in further steps below, so check abort early in case it does not match
+if ! ${python_bin} -c "from setuptools._vendor.packaging.version import Version; Version(\"${release_version}\")"; then
+    echo "Error: Found invalid release version: \"${release_version}\""
+    exit 1
+fi
+
 # check if the target is develop or release
 if [ ! ${target} = "release" ] && [ ! ${target} = "develop" ]; then
     echo "target must be release or develop"


### PR DESCRIPTION
**Purpose of the pull request**  
Abort early if the RELEASE_VERSION is invalid. Otherwise you have to wait for the full build and then run into an error very late.

**Description about the pull request**  
Uses the PEP440 check from setuptools.


