### PR TITLE
Fix: unintentional failed command during download

### DIFF
--- a/tools/utils/download_blender.sh
+++ b/tools/utils/download_blender.sh
@@ -92,7 +92,9 @@ function wait_for_all() {
         wait ${pid} &&:
         (exit $?) && (exit ${status}) &&:; status=$?
     done
-    [ ${status} -ne 0 ] && exit ${status}
+    if [ ${status} -ne 0 ]; then
+        exit ${status}
+    fi
 }
 
 function check_os() {


### PR DESCRIPTION
**Purpose of the pull request**  
Make it compatible with tests like `set -e`

**Description about the pull request**  
Currently, the changed line is always returning `false` and together with `set -e` will cause the script to fail.
