### PR TITLE
Create and archive build artifacts

### DIFF
--- a/.github/workflows/fake-bpy-module-ci.yml
+++ b/.github/workflows/fake-bpy-module-ci.yml
@@ -9,9 +9,27 @@ on:
   pull_request:
 
 jobs:
+  set_versions:
+    name: Set build versions
+    runs-on: ubuntu-latest
+    outputs:
+      module_version: ${{ steps.set_module_version.outputs.module_version }}
+      file_version: ${{ steps.set_file_version.outputs.file_version }}
+    steps:
+      # Use ISO 8601 date (in UTC) for release
+      - name: Set module version
+        id: set_module_version
+        run: echo ::set-output name=module_version::$(date -u +%Y%m%d)
+
+      # Use ISO 8601 timestamps (in UTC) for output/file version
+      - name: Set file version
+        id: set_file_version
+        run: echo ::set-output name=file_version::$(date -u +%Y%m%dT%H%M%SZ)
+
   build_modules:
     name: Build modules
     runs-on: ubuntu-18.04
+    needs: [set_versions]
     strategy:
       fail-fast: false
       matrix:
@@ -54,11 +72,22 @@ jobs:
           repository: "blender/blender"
           path: blender
 
-      - name: Set release version environment variable
-        run: echo ::set-env name=RELEASE_VERSION::$(date +%Y%m%d)
-
       - name: Generate pip Packages
+        env:
+          RELEASE_VERSION: ${{ needs.set_versions.outputs.module_version }}
         run: bash tools/pip_package/build_pip_package.sh release ${{ matrix.blender_version }} ./blender ./blender-bin/blender-v${{ matrix.blender_version }}-bin
+
+      - name: Archive pip packages
+        uses: actions/upload-artifact@v2
+        with:
+          name: fake_bpy_modules_${{ matrix.blender_version}}_pip_${{ needs.set_versions.outputs.file_version }}
+          path: release
+
+      - name: Archive raw modules
+        uses: actions/upload-artifact@v2
+        with:
+          name: fake_bpy_modules_${{ matrix.blender_version}}_raw_${{ needs.set_versions.outputs.file_version }}
+          path: "raw_modules/fake_bpy_module*"
 
       - name: Test Generated Modules
         run: bash tests/run_tests.sh raw_modules


### PR DESCRIPTION
**Purpose of the pull request**  
Create and store all build artifacts for automatic building and hence easy testing.

See artifacts for current PR: https://github.com/nutti/fake-bpy-module/actions/runs/148697983

**Description about the pull request**  
In this PR, we are creating artifacts for the "raw_modules" folder and the generated pip packages.
The pip artifact allows you to manually download and install on your local machine with the `pip install <filename>` command.

I chose a second-exact resolution timestamp for the files, as we might have multiple builds per day. While all those artifact filenames have a timestamp as a version, I did not (as requested) modify the RELEASE_VERSION.

**Additional comments** [Optional]  
EDIT: I removed all independent parts of this PR and focus primarily on generating artifacts.

Should some parts of the CI fail (for example, 2.82 fails while 2.79 builds), then the artifacts for 2.79 are still being saved. For example: https://github.com/grische/fake-bpy-module/actions/runs/148676363