### PR TITLE
Fix: gen_module only fetch tag ref

### DIFF
--- a/.github/workflows/fake-bpy-module-ci.yml
+++ b/.github/workflows/fake-bpy-module-ci.yml
@@ -49,7 +49,6 @@ jobs:
         with:
           repository: "blender/blender"
           path: blender
-          fetch-depth: 0
 
       - name: Set release version environment variable
         run: echo ::set-env name=RELEASE_VERSION::$(date +%Y%m%d)


### PR DESCRIPTION
**Purpose of the pull request**  
Speeds up tag switching tremendously

**Description about the pull request** 
Instead of fetching the full master, fetching a tag and then switching, just shallow fetch the tag directly and switch.
Speeds up the fetching during building from 2min to 15 seconds for me.

Also, rename `branch_name` to `tag_name` as no branches are being used here.

**Additional comments** [Optional]  
I tested the commit with my current Github Actions. As far as I can tell, this should not interfere anywhere.