### PR TITLE
Remove v2xx syntax in downloads

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,22 +17,22 @@ jobs:
               source ${BASH_ENV}
       - run:
           name: Generate pip Packages (Blender 2.78)
-          command: bash tools/pip_package/build_pip_package.sh release 2.78 ../blender ../blender-bin/blender-v278-bin
+          command: bash tools/pip_package/build_pip_package.sh release 2.78 ../blender ../blender-bin/blender-v2.78-bin
       - run:
           name: Generate pip Packages (Blender 2.79)
-          command: bash tools/pip_package/build_pip_package.sh release 2.79 ../blender ../blender-bin/blender-v279-bin
+          command: bash tools/pip_package/build_pip_package.sh release 2.79 ../blender ../blender-bin/blender-v2.79-bin
       - run:
           name: Generate pip Packages (Blender 2.80)
-          command: bash tools/pip_package/build_pip_package.sh release 2.80 ../blender ../blender-bin/blender-v280-bin
+          command: bash tools/pip_package/build_pip_package.sh release 2.80 ../blender ../blender-bin/blender-v2.80-bin
       - run:
           name: Generate pip Packages (Blender 2.81)
-          command: bash tools/pip_package/build_pip_package.sh release 2.81 ../blender ../blender-bin/blender-v281-bin
+          command: bash tools/pip_package/build_pip_package.sh release 2.81 ../blender ../blender-bin/blender-v2.81-bin
       - run:
           name: Generate pip Packages (Blender 2.82)
-          command: bash tools/pip_package/build_pip_package.sh release 2.82 ../blender ../blender-bin/blender-v282-bin
+          command: bash tools/pip_package/build_pip_package.sh release 2.82 ../blender ../blender-bin/blender-v2.82-bin
       - run:
           name: Generate pip Packages (Blender 2.83)
-          command: bash tools/pip_package/build_pip_package.sh release 2.83 ../blender ../blender-bin/blender-v283-bin
+          command: bash tools/pip_package/build_pip_package.sh release 2.83 ../blender ../blender-bin/blender-v2.83-bin
       - run:
           name: Compress All Generated Packages
           command: tar cvfz all.tar.gz release/* && mv all.tar.gz release

--- a/.github/workflows/fake-bpy-module-ci.yml
+++ b/.github/workflows/fake-bpy-module-ci.yml
@@ -57,22 +57,22 @@ jobs:
         # TODO: In the future, the following commands should be replaced by a matrix:
         # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
       - name: Generate pip Packages (Blender 2.78)
-        run: bash tools/pip_package/build_pip_package.sh release 2.78 ./blender ./blender-bin/blender-v278-bin
+        run: bash tools/pip_package/build_pip_package.sh release 2.78 ./blender ./blender-bin/blender-v2.78-bin
 
       - name: Generate pip Packages (Blender 2.79)
-        run: bash tools/pip_package/build_pip_package.sh release 2.79 ./blender ./blender-bin/blender-v279-bin
+        run: bash tools/pip_package/build_pip_package.sh release 2.79 ./blender ./blender-bin/blender-v2.79-bin
 
       - name: Generate pip Packages (Blender 2.80)
-        run: bash tools/pip_package/build_pip_package.sh release 2.80 ./blender ./blender-bin/blender-v280-bin
+        run: bash tools/pip_package/build_pip_package.sh release 2.80 ./blender ./blender-bin/blender-v2.80-bin
 
       - name: Generate pip Packages (Blender 2.81)
-        run: bash tools/pip_package/build_pip_package.sh release 2.81 ./blender ./blender-bin/blender-v281-bin
+        run: bash tools/pip_package/build_pip_package.sh release 2.81 ./blender ./blender-bin/blender-v2.81-bin
 
       - name: Generate pip Packages (Blender 2.82)
-        run: bash tools/pip_package/build_pip_package.sh release 2.82 ./blender ./blender-bin/blender-v282-bin
+        run: bash tools/pip_package/build_pip_package.sh release 2.82 ./blender ./blender-bin/blender-v2.82-bin
 
       - name: Generate pip Packages (Blender 2.83)
-        run: bash tools/pip_package/build_pip_package.sh release 2.83 ./blender ./blender-bin/blender-v283-bin
+        run: bash tools/pip_package/build_pip_package.sh release 2.83 ./blender ./blender-bin/blender-v2.83-bin
 
       - name: Test Generated Modules
         run: bash tests/run_tests.sh raw_modules

--- a/tools/utils/download_blender.sh
+++ b/tools/utils/download_blender.sh
@@ -9,47 +9,47 @@ SUPPORTED_VERSIONS=(
 )
 
 declare -A BLENDER_DOWNLOAD_URL_MACOSX=(
-    ["v278"]="https://download.blender.org/release/Blender2.78/blender-2.78c-OSX_10.6-x86_64.zip"
-    ["v279"]="https://download.blender.org/release/Blender2.79/blender-2.79a-macOS-10.6.zip"
-    ["v280"]=""
-    ["v281"]=""
-    ["v282"]=""
-    ["v283"]=""
+    ["v2.78"]="https://download.blender.org/release/Blender2.78/blender-2.78c-OSX_10.6-x86_64.zip"
+    ["v2.79"]="https://download.blender.org/release/Blender2.79/blender-2.79a-macOS-10.6.zip"
+    ["v2.80"]=""
+    ["v2.81"]=""
+    ["v2.82"]=""
+    ["v2.83"]=""
 )
 
 declare -A BLENDER_DOWNLOAD_URL_WIN64=(
-    ["v278"]="https://download.blender.org/release/Blender2.78/blender-2.78c-windows64.zip"
-    ["v279"]="https://download.blender.org/release/Blender2.79/blender-2.79b-windows64.zip"
-    ["v280"]="https://download.blender.org/release/Blender2.80/blender-2.80-windows64.zip"
-    ["v281"]="https://download.blender.org/release/Blender2.81/blender-2.81a-windows64.zip"
-    ["v282"]="https://download.blender.org/release/Blender2.82/blender-2.82a-windows64.zip"
-    ["v283"]="https://download.blender.org/release/Blender2.83/blender-2.83.0-windows64.zip"
+    ["v2.78"]="https://download.blender.org/release/Blender2.78/blender-2.78c-windows64.zip"
+    ["v2.79"]="https://download.blender.org/release/Blender2.79/blender-2.79b-windows64.zip"
+    ["v2.80"]="https://download.blender.org/release/Blender2.80/blender-2.80-windows64.zip"
+    ["v2.81"]="https://download.blender.org/release/Blender2.81/blender-2.81a-windows64.zip"
+    ["v2.82"]="https://download.blender.org/release/Blender2.82/blender-2.82a-windows64.zip"
+    ["v2.83"]="https://download.blender.org/release/Blender2.83/blender-2.83.0-windows64.zip"
 )
 
 declare -A BLENDER_DOWNLOAD_URL_LINUX=(
-    ["v278"]="https://download.blender.org/release/Blender2.78/blender-2.78c-linux-glibc219-x86_64.tar.bz2"
-    ["v279"]="https://download.blender.org/release/Blender2.79/blender-2.79b-linux-glibc219-x86_64.tar.bz2"
-    ["v280"]="https://download.blender.org/release/Blender2.80/blender-2.80-linux-glibc217-x86_64.tar.bz2"
-    ["v281"]="https://download.blender.org/release/Blender2.81/blender-2.81a-linux-glibc217-x86_64.tar.bz2"
-    ["v282"]="https://download.blender.org/release/Blender2.82/blender-2.82a-linux64.tar.xz"
-    ["v283"]="https://download.blender.org/release/Blender2.83/blender-2.83.0-linux64.tar.xz"
+    ["v2.78"]="https://download.blender.org/release/Blender2.78/blender-2.78c-linux-glibc219-x86_64.tar.bz2"
+    ["v2.79"]="https://download.blender.org/release/Blender2.79/blender-2.79b-linux-glibc219-x86_64.tar.bz2"
+    ["v2.80"]="https://download.blender.org/release/Blender2.80/blender-2.80-linux-glibc217-x86_64.tar.bz2"
+    ["v2.81"]="https://download.blender.org/release/Blender2.81/blender-2.81a-linux-glibc217-x86_64.tar.bz2"
+    ["v2.82"]="https://download.blender.org/release/Blender2.82/blender-2.82a-linux64.tar.xz"
+    ["v2.83"]="https://download.blender.org/release/Blender2.83/blender-2.83.0-linux64.tar.xz"
 )
 
 declare -A NEED_MOVE_MACOSX=(
-    ["v278"]="blender-2.78c-OSX_10.6-x86_64"
-    ["v279"]="blender-2.79b-macOS-10.6"
+    ["v2.78"]="blender-2.78c-OSX_10.6-x86_64"
+    ["v2.79"]="blender-2.79b-macOS-10.6"
 )
 
 declare -A NEED_MOVE_WIN64=(
 )
 
 declare -A NEED_MOVE_LINUX=(
-    ["v278"]="blender-2.78c-linux-glibc219-x86_64"
-    ["v279"]="blender-2.79b-linux-glibc219-x86_64"
-    ["v280"]="blender-2.80-linux-glibc217-x86_64"
-    ["v281"]="blender-2.81a-linux-glibc217-x86_64"
-    ["v282"]="blender-2.82a-linux64"
-    ["v283"]="blender-2.83.0-linux64"
+    ["v2.78"]="blender-2.78c-linux-glibc219-x86_64"
+    ["v2.79"]="blender-2.79b-linux-glibc219-x86_64"
+    ["v2.80"]="blender-2.80-linux-glibc217-x86_64"
+    ["v2.81"]="blender-2.81a-linux-glibc217-x86_64"
+    ["v2.82"]="blender-2.82a-linux64"
+    ["v2.83"]="blender-2.83.0-linux64"
 )
 
 function download_blender() {
@@ -176,7 +176,7 @@ if [ ${version} = "all" ]; then
     wait_for_all ${pids[@]}
 else
     if [ ${os} == "Mac" ]; then
-        ver=v${version%.*}${version##*.}
+        ver=v${version}
         url=${BLENDER_DOWNLOAD_URL_MACOSX[${ver}]}
         move_from=""
         if [[ "${NEED_MOVE_MACOSX[${ver}]+_}" == "_" ]]; then
@@ -184,7 +184,7 @@ else
         fi
         download_blender ${ver} ${url} ${move_from}
     elif [ ${os} == "Cygwin64" ]; then
-        ver=v${version%.*}${version##*.}
+        ver=v${version}
         url=${BLENDER_DOWNLOAD_URL_WIN64[${ver}]}
         move_from=""
         if [[ "${NEED_MOVE_WIN64[${ver}]+_}" == "_" ]]; then
@@ -192,7 +192,7 @@ else
         fi
         download_blender ${ver} ${url} ${move_from}
     elif [ ${os} == "Linux" ]; then
-        ver=v${version%.*}${version##*.}
+        ver=v${version}
         url=${BLENDER_DOWNLOAD_URL_LINUX[${ver}]}
         move_from=""
         if [[ "${NEED_MOVE_LINUX[${ver}]+_}" == "_" ]]; then


### PR DESCRIPTION
**Purpose of the pull request**  
Create a consistent naming syntax. Currently, the `2.xx` syntax is used in some scripts, while `v2xx` is used in others. Trying to make them easily convertible (by adding/stripping `v` at the start)

**Description about the pull request**  
Replace array addressing with `v2xx` syntax, making the download directories not use the `v2xx` syntax.

Additionally, cleaning up the `build_pip_package.sh` script internally to purge the old syntax. These two commits can be split up in different PRs if you prefer.

**Additional comments** [Optional]  
The consistent naming in the download folders is required to make the CI job easily run in parallel on Github Actions. Without it, it will cause a lot of (unnecessary) additional code.