### PR TITLE
Add: Cleanup old artifacts

### DIFF
--- a/.github/workflows/fake-bpy-module-ci.yml
+++ b/.github/workflows/fake-bpy-module-ci.yml
@@ -62,3 +62,16 @@ jobs:
 
       - name: Test Generated Modules
         run: bash tests/run_tests.sh raw_modules
+
+  cleanup_artifacts:
+    name: Cleanup old artifacts
+    runs-on: ubuntu-latest
+    needs: [build_modules]
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Cleanup old artifacts
+        uses: c-hive/gha-remove-artifacts@v1.2.0
+        with:
+          age: "2 month"
+          skip-tags: true
+          skip-recent: 10


### PR DESCRIPTION
**Purpose of the pull request**  
Clean up old artifacts automatically.

**Description about the pull request**  
This PR is a split from #51 and only makes sense if #51 is merged.

It might be worth noting, that external repositories on Github Actions (i.e. [c-hive/gha-remove-artifacts](https://github.com/marketplace/actions/remove-artifacts)) require trust in the third party as it can contain malicious code (and malicious code can be added easily later) as far as I am aware. That's why I split the feature into a separate commit.

I [measured the build artifacts we are creating and they are in total around 10MB](https://github.com/grische/fake-bpy-module/actions/runs/142227477) for each commit to master. It seems, Github has no limit on build artifacts (but when they reach around 5GB, it seems a bug is triggered): https://github.com/actions/upload-artifact/issues/9

This means that for 500 builds/commits everything is fine and by the time this repo reaches 500 builds on master, the bug is probably already fixed.

Would you like to have this PR?