### PR TITLE
Verify Blender downloads and keep them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tools/pip_package/tmp-*
 # ignore artifacts
 release
 raw_modules
+
+# ignore blender downloads
+downloads


### PR DESCRIPTION
**Purpose of the pull request**  
This avoids re-downloading Blender binary files when building pip  packages locally.

**Description about the pull request**  
Download files to a "downloads/" folder and keep binaries there.
On each download attempt verify the integrity existing downloads and in case of a failure, re-download them.

**Additional comments** [Optional]  
This depends on #62 