### PR TITLE
auto PyPi publishing

### DIFF
--- a/.github/workflows/fake-bpy-module-ci.yml
+++ b/.github/workflows/fake-bpy-module-ci.yml
@@ -20,10 +20,24 @@ jobs:
       module_version: ${{ steps.set_module_version.outputs.module_version }}
       file_version: ${{ steps.set_file_version.outputs.file_version }}
     steps:
-      # Use ISO 8601 date (in UTC) for release
+      # Use ISO 8601 date (in UTC) + timestamp (in UTC)
+      - name: Create generic module version
+        run: echo ::set-env name=MODULE_VERSION::$(date -u +%Y%m%d).dev$(date -u +%H%M%S)
+
+      # Use the tag name for a release
+      - name: Override release module version
+        if: github.event_name == 'release'
+        run: echo ::set-env name=MODULE_VERSION::${GITHUB_REF#refs/*/}
+
+      # Add addtional git sha ref
+      - name: Override PR module version
+        if: github.event_name == 'pull_request'
+        run: echo ::set-env name=MODULE_VERSION::${MODULE_VERSION}+${GITHUB_SHA::8}
+
+      # Set module version output
       - name: Set module version
         id: set_module_version
-        run: echo ::set-output name=module_version::$(date -u +%Y%m%d)
+        run: echo ::set-output name=module_version::${MODULE_VERSION}
 
       # Use ISO 8601 timestamps (in UTC) for output/file version
       - name: Set file version

--- a/.github/workflows/fake-bpy-module-ci.yml
+++ b/.github/workflows/fake-bpy-module-ci.yml
@@ -7,6 +7,10 @@ on:
       - ci_testing
       - master
   pull_request:
+  # Only trigger on released (not pre-released) events
+  release:
+    types:
+      - released
 
 jobs:
   set_versions:
@@ -91,3 +95,30 @@ jobs:
 
       - name: Test Generated Modules
         run: bash tests/run_tests.sh raw_modules
+
+  publish_modules:
+    name: Upload artifacts to PyPi
+    needs: build_modules
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: dist
+
+        # Publish to TestPyPi on each merge to master
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.3.1
+        with:
+          password: ${{ secrets.test_pypi_token }}
+          repository_url: https://test.pypi.org/legacy/
+          packages_dir: "dist/*/*/"
+
+        # Publish to PyPi in case a Github release is created
+      - name: Publish distribution 📦 to PyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@v1.3.1
+        with:
+          password: ${{ secrets.pypi_token }}
+          packages_dir: "dist/*/*/"


### PR DESCRIPTION
**Purpose of the pull request**  
Make the PyPi publishing process automatic without manual user intervention.

**Description about the pull request**  
1. It adds a new trigger for Github releases.
1. It changes versioning scheme 
   1. default: `YYYYmmdd.devHHMMSS`
   2. releases: infer version from tag name
   3. PRs: use default + githash: `YYYYmmdd.devHHMMSS+abcdef01`
1. Automatically builds + publishes all non-PRs to TestPyPi
1. Automatically builds + publishes all GitHub releases to PyPi


**Additional comments**
Do you want me to split the PR into two separate ones? 
1. For changing the versioning scheme
1. For adding the PyPi publishing


**Release workflow**
In order to publish automatically to PyPi, you have to [go into releases](https://github.com/nutti/fake-bpy-module/releases) and create a new release (be aware that "Pre-Releases" do not count!).

This will then trigger a Github Action which publishes to PyPi.

Example:
* Github Release: https://github.com/grische/fake-bpy-module/releases/tag/20191013
* Action workflow: https://github.com/grische/fake-bpy-module/actions/runs/164700535 
![image](https://user-images.githubusercontent.com/2787581/87169047-afb33e80-c2cf-11ea-9dfc-8d52cd03478a.png)
