### PR TITLE
Change: replace a == x to a in (x)

### DIFF
--- a/src/fake_bpy_module/analyzer.py
+++ b/src/fake_bpy_module/analyzer.py
@@ -395,9 +395,9 @@ class BaseAnalyzer:
         current = ""
         line_to_parse = line
         for c in line_to_parse:
-            if c == "(" or c == "{" or c == "[":
+            if c in ("(", "{", "["):
                 level += 1
-            elif c ==")" or c == "}" or c == "]":
+            elif c in (")", "}", "]"):
                 level -= 1
                 if level < 0:
                     raise ValueError("Level must be >= 0 but {} (File name: {}, Line: {})"


### PR DESCRIPTION
**Purpose of the pull request**  
Trying to make code easier readable

**Description about the pull request**  
R1714: Consider merging these comparisons with "in" to "c in ('(', '{', '[')" (consider-using-in)