### PR TITLE
Change: Add --python-exit-code to blender calls

### DIFF
--- a/docs/generate_modules.md
+++ b/docs/generate_modules.md
@@ -134,7 +134,7 @@ git checkout [branch/tag/commit]
 Generated .rst documents are located on `${BLENDER_SRC}/doc/python_api/sphinx-in`.
 
 ```bash
-${BLENDER_BIN}/blender --background --factory-startup -noaudio --python doc/python_api/sphinx_doc_gen.py
+${BLENDER_BIN}/blender --background --factory-startup -noaudio --python-exit-code 1 --python doc/python_api/sphinx_doc_gen.py
 ```
 
 
@@ -160,7 +160,7 @@ https://github.com/nutti/fake-bpy-module/archive/master.zip
 cd fake-bpy-module/src
 
 mkdir -p mods/generated_mods
-${BLENDER_BIN}/blender --background --factory-startup -noaudio --python gen_modfile/gen_modules_modfile.py -- -m addon_utils -o mods/generated_mods/gen_modules_modfile
+${BLENDER_BIN}/blender --background --factory-startup -noaudio --python-exit-code 1 --python gen_modfile/gen_modules_modfile.py -- -m addon_utils -o mods/generated_mods/gen_modules_modfile
 
 mkdir -p mods/generated_mods/gen_startup_modfile
 python gen_modfile/gen_startup_modfile.py -i ${BLENDER_BIN}/<blender-version>/scripts/startup -o mods/generated_mods/gen_startup_modfile/bpy.json

--- a/src/gen_module.sh
+++ b/src/gen_module.sh
@@ -108,7 +108,7 @@ function revert_workaround() {
 # generate .rst documents
 cd ${current_dir}
 apply_workaround
-${blender_bin} --background --factory-startup -noaudio --python ${source_dir}/doc/python_api/sphinx_doc_gen.py -- --output ${tmp_dir}
+${blender_bin} --background --factory-startup -noaudio --python-exit-code 1 --python ${source_dir}/doc/python_api/sphinx_doc_gen.py -- --output ${tmp_dir}
 revert_workaround
 
 # Apply patches
@@ -132,8 +132,8 @@ if [ $? -ne 0 ]; then
 fi
 generated_mod_dir=${SCRIPT_DIR}/mods/generated_mods
 mkdir -p ${generated_mod_dir}
-${blender_bin} --background --factory-startup -noaudio --python ${SCRIPT_DIR}/gen_modfile/gen_external_modules_modfile.py -- -m addon_utils -o ${generated_mod_dir}/gen_modules_modfile
-${blender_bin} --background --factory-startup -noaudio --python ${SCRIPT_DIR}/gen_modfile/gen_external_modules_modfile.py -- -m keyingsets_builtins -a -o ${generated_mod_dir}/gen_startup_modfile
+${blender_bin} --background --factory-startup -noaudio --python-exit-code 1 --python ${SCRIPT_DIR}/gen_modfile/gen_external_modules_modfile.py -- -m addon_utils -o ${generated_mod_dir}/gen_modules_modfile
+${blender_bin} --background --factory-startup -noaudio --python-exit-code 1 --python ${SCRIPT_DIR}/gen_modfile/gen_external_modules_modfile.py -- -m keyingsets_builtins -a -o ${generated_mod_dir}/gen_startup_modfile
 mkdir -p ${generated_mod_dir}/gen_bgl_modfile
 ${python_bin} ${SCRIPT_DIR}/gen_modfile/gen_bgl_modfile.py -i ${source_dir}/source/blender/python/generic/bgl.c -o ${generated_mod_dir}/gen_bgl_modfile/bgl.json
 


### PR DESCRIPTION
**Purpose of the pull request**  
To let the CI runs not ignore Python exceptions

**Description about the pull request**  
This will show currently silent errors and abort scripts if there has
been a Python exception raised somewhere in Blender.


**Additional comments** [Optional]  
Suggested when reporting https://developer.blender.org/T82494