### PR TITLE
Update generate_modules.md

### DIFF
--- a/docs/generate_modules.md
+++ b/docs/generate_modules.md
@@ -45,7 +45,7 @@ Download Blender whose version is the version you try to generate modules.
 ### 2. Download Blender sources
 
 ```bash
-git clone git://git.blender.org/blender.git
+git clone https://projects.blender.org/blender/blender.git
 ```
 
 ### 3. Download fake-bpy-module sources


### PR DESCRIPTION
Old git link didn't work

<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

Fix outdated link to make it easier to follow the wiki by copying commands.

### Description about the pull request

The old link gave this error:  
```
> git clone https://git.blender.org/blender.git
Cloning into 'blender'...
fatal: unable to connect to git.blender.org:
git.blender.org[0: 82.94.226.104]: errno=Unknown error
```
