### PR TITLE
Update: Remove sub-package py.typed

### DIFF
--- a/src/fake_bpy_module/generator.py
+++ b/src/fake_bpy_module/generator.py
@@ -1306,12 +1306,14 @@ class PackageGenerator:
                         dir_path = path + "/" + item.name
                         pathlib.Path(dir_path).mkdir(
                             parents=True, exist_ok=True)
-                        self._create_py_typed_file(dir_path)
+                        if module_level == 0:
+                            self._create_py_typed_file(dir_path)
                     elif len(item.children()) >= 1:
                         dir_path = path + "/" + item.name
                         pathlib.Path(dir_path).mkdir(
                             parents=True, exist_ok=True)
-                        self._create_py_typed_file(dir_path)
+                        if module_level == 0:
+                            self._create_py_typed_file(dir_path)
                         if dir_path == base_path:
                             continue
                         make_dir(dir_path, item, module_level+1)


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

- Described in #167.

### Description about the pull request

Only generate `py.typed` files at top-level (`module_level` = 0).
