### PR TITLE
Fix: Add missing default argument in code generation tests

### DIFF
--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test.py
@@ -172,7 +172,7 @@ class GeneratorsTest(common.FakeBpyModuleTestBase):
     def _create_function_info(self):
         info = FunctionInfo("function")
         info.set_name("function_1")
-        info.set_parameters(["param_1=10", "param_2", "param_3=4.5"])
+        info.set_parameters(["param_1=10", "param_2=[]", "param_3=4.5"])
         info.set_description("function_1 description")
         info.set_module("module_1")
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/base_generator_test_dump_json.json
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/base_generator_test_dump_json.json
@@ -20,7 +20,7 @@
         "module": "module_1",
         "parameters": [
             "param_1=10",
-            "param_2",
+            "param_2=[]",
             "param_3=4.5"
         ],
         "parameter_details": [

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/base_generator_test_generate.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/base_generator_test_generate.py
@@ -43,7 +43,7 @@ class ClassA(BaseClassB, BaseClassA):
 
 
 def function_1(param_1: int = 10,
-               param_2: typing.List['ClassA'],
+               param_2: typing.List['ClassA'] = [],
                param_3: typing.Optional[float] = 4.5) -> bool:
     ''' function_1 description
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/base_generator_test_generate.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/base_generator_test_generate.pyi
@@ -43,7 +43,7 @@ class ClassA(BaseClassB, BaseClassA):
 
 
 def function_1(param_1: int = 10,
-               param_2: typing.List['ClassA'],
+               param_2: typing.List['ClassA'] = [],
                param_3: typing.Optional[float] = 4.5) -> bool:
     ''' function_1 description
 


### PR DESCRIPTION
### Purpose of the pull request

The missing default argument of `param_2` caused a syntax error

### Description about the pull request

The default argument of `param_2` was specified in `parameter_details` but not in `parameters`.
The different test and fixtures have been updated accordingly.
