### PR TITLE
Add gen modules scripts

### DIFF
--- a/docs/generate_modules.md
+++ b/docs/generate_modules.md
@@ -7,6 +7,7 @@ You can choose the method to generate modules.
 
 1. [Case 1: Use utility script](#case-1-use-utility-script)
 2. [Case 2: Do it yourself all procedures](#case-2-do-it-yourself-all-procedures)
+3. [Case 3: Do Case 2 inside Docker](#case-3-do-case-2-inside-docker)
 
 ## Pre-requirement
 
@@ -194,3 +195,29 @@ python gen.py -i <input-dir> -o <output-dir> -f <format> -b <blender-version> -m
 * `-m <mod-version>`: Modify APIs by using patch files located in `mods` directory.
   * If you specify `2.80`, all patch files under `mods/2.80` will be used.
   * Files located in `mods/common` directories will be used at any time.
+
+## Case 3: Do Case 2 inside Docker
+
+### Run script
+
+<!-- markdownlint-disable MD013 -->
+```bash
+bash tools/gen_module/run_gen_module.sh <blender-version>
+```
+<!-- markdownlint-enable MD013 -->
+
+* `<blender-version>`: Specify blender version.
+
+`<mod-version>` is automatically determined by `<blender-version>` version.
+
+### Results
+
+| Directory | Contents |
+|----|----|
+| `build/blender-bin` | Blender binaries |
+| `build/blender-src` | Blender source code |
+| `build/examples` | Blender Python API sample code |
+| `build/results` | Result `*.pyi` files |
+| `build/sphinx-in` | Blender Python API documents |
+| `build/sphinx-in-tmp` | ??? |
+| `downloads` | Blender archives |

--- a/docs/github_actions_tests.md
+++ b/docs/github_actions_tests.md
@@ -1,0 +1,37 @@
+# Run GitHub Actions Tests
+
+This document shows the procedure for GitHub Actions debug and test in local docker.
+
+## Pre-requirement
+
+### Docker in Docker
+
+A docker container must be able to mount `/var/run/docker.sock`
+to run GitHub Actions inside docker.
+So only tested in Linux environment.
+
+### GitHub personal access token
+
+A GitHub personal access token may be required to run workflows.
+Which must have Public Repositories (read-only) access.
+
+See: [Managing your personal access tokens - GitHub Docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+
+## Run GitHub Actions
+
+You can run GitHub Actions using the following commands:
+<!-- markdownlint-disable MD013 -->
+* Fast (set_versions) test
+  * `bash tools/github_actions_tests/run_github_actions_tests.sh --job set_versions`
+* List jobs
+  * `bash tools/github_actions_tests/run_github_actions_tests.sh --list`
+* Lint
+  * `bash tools/github_actions_tests/run_github_actions_tests.sh --workflows .github/workflows/lint.yml push`
+* Latest bulid test
+  * `bash tools/github_actions_tests/run_github_actions_tests.sh --workflows .github/workflows/fake-bpy-module-latest-build.yml --job build_modules`
+* All push test
+  * `bash tools/github_actions_tests/run_github_actions_tests.sh push`
+* Show help
+  * `bash tools/github_actions_tests/run_github_actions_tests.sh --help`
+  * Detailed command examples: <https://github.com/nektos/act#example-commands>
+<!-- markdownlint-disable MD013 -->

--- a/tools/gen_module/Dockerfile
+++ b/tools/gen_module/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.8-bullseye
+
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
+    git \
+    libglu1-mesa libegl1 libxxf86vm1 libxfixes3 libxi6 libxkbcommon0 libgl1 \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY src/requirements.txt src/requirements.txt
+RUN pip install --no-cache-dir -r src/requirements.txt

--- a/tools/gen_module/run_gen_module.sh
+++ b/tools/gen_module/run_gen_module.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -eEu -o pipefail
+
+# Define directory variables
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+WORKSPACE_DIR=$( realpath "${SCRIPT_DIR}/../.." )
+
+BUILD_DIR="build"
+BLENDER_BIN_DIR="${BUILD_DIR}/blender-bin"
+BLENDER_SRC_DIR="${BUILD_DIR}/blender-src"
+
+# Define dependency script paths
+BUILD_PIP_PACKAGE_SCRIPT_PATH="${WORKSPACE_DIR}/tools/pip_package/build_pip_package.sh"
+
+# Define supported versions and tag names
+SUPPORTED_BLENDER_VERSIONS=()
+declare -A BLENDER_TAG_NAME=()
+
+## Import variables from build_pip_package.sh
+## shellcheck disable=SC1090
+eval "$(sed -n '/^SUPPORTED_BLENDER_VERSIONS/,/^TMP_DIR_NAME/{/^TMP_DIR_NAME/!p}' "${BUILD_PIP_PACKAGE_SCRIPT_PATH}")"
+
+# Check arguments
+if [[ $# != 1 ]]; then
+    echo "Usage: bash ${BASH_SOURCE[0]} <target_version>"
+	echo "  Available <target_version>: " "${SUPPORTED_BLENDER_VERSIONS[@]}"
+    exit 1
+fi
+
+target_version="${1}"
+
+# Check target version is supported
+if [[ ! " ${SUPPORTED_BLENDER_VERSIONS[*]} " == *" ${target_version} "* ]]; then
+	echo "Error: Unsupported Blender version: ${target_version}"
+	exit 2
+fi
+
+# Create BUILD_DIR if not exist
+[[ ! -d "${WORKSPACE_DIR}/${BUILD_DIR}" ]] && mkdir -p "${WORKSPACE_DIR}/${BUILD_DIR}"
+
+# Download Blender source code
+if [[ ! -d "${WORKSPACE_DIR}/${BLENDER_SRC_DIR}" ]]; then
+	git clone https://github.com/blender/blender.git "${WORKSPACE_DIR}/${BLENDER_SRC_DIR}"
+# else
+	# (cd "${WORKSPACE_DIR}/${BLENDER_SRC_DIR}" && git fetch --all)
+fi
+
+# Checkout Blender source code to target_version
+# Comment next line because gen_module.sh checkout target_version.
+# (cd "${WORKSPACE_DIR}/${BLENDER_SRC_DIR}" && git checkout "${BLENDER_TAG_NAME["v${target_version}"]}")
+
+# Define docker run parameters
+docker_run_parameters=(
+	"-it" "--rm"
+	"--user" "$(id -u):$(id -g)"
+	"--mount" "type=bind,source=${WORKSPACE_DIR},target=/workspace"
+	"--workdir" "/workspace"
+	"$(cd "${WORKSPACE_DIR}" && docker build -q -f tools/gen_module/Dockerfile .)"
+)
+
+# Download Blender binary if not exist
+BLENDER_TARGET_BIN_DIR="${BLENDER_BIN_DIR}/blender-v${target_version}-bin"
+if [[ ! -d "${WORKSPACE_DIR}/${BLENDER_TARGET_BIN_DIR}" ]]; then
+	# Run download_blender.sh in docker to download the Linux version
+	docker run "${docker_run_parameters[@]}" \
+		/bin/bash "tools/utils/download_blender.sh" "${target_version}" "${BLENDER_BIN_DIR}"
+fi
+
+# Define gen_module.sh parameters
+gen_module_parameters=(
+	"${BLENDER_SRC_DIR}"
+	"${BLENDER_TARGET_BIN_DIR}"
+	"blender"
+	"${BLENDER_TAG_NAME[v${target_version}]}"
+	"${target_version}"
+	"${BUILD_DIR}/results"
+)
+
+# Run gen_module.sh in docker
+docker run --env TEMPORARY_DIR="${BUILD_DIR}" "${docker_run_parameters[@]}" \
+	/bin/bash src/gen_module.sh "${gen_module_parameters[@]}"

--- a/tools/gen_module/run_gen_module_in_docker.sh
+++ b/tools/gen_module/run_gen_module_in_docker.sh
@@ -23,7 +23,7 @@ eval "$(sed -n '/^SUPPORTED_BLENDER_VERSIONS/,/^TMP_DIR_NAME/{/^TMP_DIR_NAME/!p}
 # Check arguments
 if [[ $# != 1 ]]; then
     echo "Usage: bash ${BASH_SOURCE[0]} <target_version>"
-	echo "  Available <target_version>: " "${SUPPORTED_BLENDER_VERSIONS[@]}"
+    echo "  Available <target_version>: " "${SUPPORTED_BLENDER_VERSIONS[@]}"
     exit 1
 fi
 
@@ -31,8 +31,8 @@ target_version="${1}"
 
 # Check target version is supported
 if [[ ! " ${SUPPORTED_BLENDER_VERSIONS[*]} " == *" ${target_version} "* ]]; then
-	echo "Error: Unsupported Blender version: ${target_version}"
-	exit 2
+    echo "Error: Unsupported Blender version: ${target_version}"
+    exit 2
 fi
 
 # Create BUILD_DIR if not exist
@@ -40,42 +40,36 @@ fi
 
 # Download Blender source code
 if [[ ! -d "${WORKSPACE_DIR}/${BLENDER_SRC_DIR}" ]]; then
-	git clone https://github.com/blender/blender.git "${WORKSPACE_DIR}/${BLENDER_SRC_DIR}"
-# else
-	# (cd "${WORKSPACE_DIR}/${BLENDER_SRC_DIR}" && git fetch --all)
+    git clone https://github.com/blender/blender.git "${WORKSPACE_DIR}/${BLENDER_SRC_DIR}"
 fi
-
-# Checkout Blender source code to target_version
-# Comment next line because gen_module.sh checkout target_version.
-# (cd "${WORKSPACE_DIR}/${BLENDER_SRC_DIR}" && git checkout "${BLENDER_TAG_NAME["v${target_version}"]}")
 
 # Define docker run parameters
 docker_run_parameters=(
-	"-it" "--rm"
-	"--user" "$(id -u):$(id -g)"
-	"--mount" "type=bind,source=${WORKSPACE_DIR},target=/workspace"
-	"--workdir" "/workspace"
-	"$(cd "${WORKSPACE_DIR}" && docker build -q -f tools/gen_module/Dockerfile .)"
+    "-it" "--rm"
+    "--user" "$(id -u):$(id -g)"
+    "--mount" "type=bind,source=${WORKSPACE_DIR},target=/workspace"
+    "--workdir" "/workspace"
+    "$(cd "${WORKSPACE_DIR}" && docker build -q -f tools/gen_module/Dockerfile .)"
 )
 
 # Download Blender binary if not exist
 BLENDER_TARGET_BIN_DIR="${BLENDER_BIN_DIR}/blender-v${target_version}-bin"
 if [[ ! -d "${WORKSPACE_DIR}/${BLENDER_TARGET_BIN_DIR}" ]]; then
-	# Run download_blender.sh in docker to download the Linux version
-	docker run "${docker_run_parameters[@]}" \
-		/bin/bash "tools/utils/download_blender.sh" "${target_version}" "${BLENDER_BIN_DIR}"
+    # Run download_blender.sh in docker to download the Linux version
+    docker run "${docker_run_parameters[@]}" \
+        /bin/bash "tools/utils/download_blender.sh" "${target_version}" "${BLENDER_BIN_DIR}"
 fi
 
 # Define gen_module.sh parameters
 gen_module_parameters=(
-	"${BLENDER_SRC_DIR}"
-	"${BLENDER_TARGET_BIN_DIR}"
-	"blender"
-	"${BLENDER_TAG_NAME[v${target_version}]}"
-	"${target_version}"
-	"${BUILD_DIR}/results"
+    "${BLENDER_SRC_DIR}"
+    "${BLENDER_TARGET_BIN_DIR}"
+    "blender"
+    "${BLENDER_TAG_NAME[v${target_version}]}"
+    "${target_version}"
+    "${BUILD_DIR}/results"
 )
 
 # Run gen_module.sh in docker
 docker run --env TEMPORARY_DIR="${BUILD_DIR}" "${docker_run_parameters[@]}" \
-	/bin/bash src/gen_module.sh "${gen_module_parameters[@]}"
+    /bin/bash src/gen_module.sh "${gen_module_parameters[@]}"

--- a/tools/github_actions_tests/run_github_actions_tests.sh
+++ b/tools/github_actions_tests/run_github_actions_tests.sh
@@ -14,7 +14,7 @@ if [ $# -lt 1 ]; then
 fi
 
 if [[ ! -v GITHUB_TOKEN ]]; then
-    echo "Error: GITHUB_TOKEN is not set. Please set GITHUB_TOKEN to your GitHub private access token, which must have Public Repositories (read-only) access."
+    echo "Error: GITHUB_TOKEN is not set. Please set GITHUB_TOKEN to your GitHub personal access token, which must have Public Repositories (read-only) access."
     echo "  For example: GITHUB_TOKEN=github_pat_XXXXXXXXXXXXXXXXXXXXXXXX bash ${BASH_SOURCE[0]}" "$@"
     exit 2
 fi


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

* Allow easy module generation for any Blender version

### Description about the pull request

* Shortcut time-consuming build processes by comparing file timestamps
* Add `run_gen_module.sh` to easily run `gen_module.sh` in docker

#### `run_gen_module.sh` Usage
```bash
$ bash tools/utils/run_gen_module.sh
Usage: bash tools/utils/run_gen_module.sh <target_version>
  Available <target_version>: 2.78 2.79 2.80 2.81 2.82 2.83 2.90 2.91 2.92 2.93 3.0 3.1 3.2 3.3 3.4 3.5 3.6 4.0 latest

$ bash tools/utils/run_gen_module.sh 4.0
... build log ...
```

The results are output to `build` directory.
```bash
$ ls build
blender-bin  blender-src  examples  generated_mods  results  sphinx-in  sphinx-in-tmp
```

| Directory | Contents |
|----|----|
| `build/blender-bin` | Blender binaries |
| `build/blender-src` | Blender source code |
| `build/examples` | Blender Python API sample code |
| `build/generated_mods` | ??? mods |
| `build/results` | Result `*.pyi` files |
| `build/sphinx-in` | Blender Python API documents |
| `build/sphinx-in-tmp` | ??? |