### PR TITLE
Pre-compile regular expressions for speed

### DIFF
--- a/src/fake_bpy_module/common.py
+++ b/src/fake_bpy_module/common.py
@@ -88,6 +88,7 @@ MODIFIER_DATA_TYPE_TO_TYPING: Dict[str, str] = {
 ALLOWED_CHAR_BEFORE = {" ", "("}
 ALLOWED_CHAR_AFTER = {" ", ",", ")"}
 
+
 def has_data_type(str_: str, data_type: str) -> bool:
     start_index = 0
     end_index = len(str_)
@@ -98,7 +99,7 @@ def has_data_type(str_: str, data_type: str) -> bool:
         si = str_.find(data_type, ei + 1)
         if si == -1:
             return False
-        
+
         ei = si + data_type_len
         # example: "int"
         if (si == start_index) and (ei == end_index):
@@ -150,37 +151,36 @@ REGEX_SUB_DATA_TYPE_STRIP = re.compile("|".join([
     r"`",
 ]))
 
+# pylint: disable=line-too-long
 REGEX_MATCH_DATA_TYPE_SPACE = re.compile(r"^\s*$")
-REGEX_MATCH_DATA_TYPE_ENUM_IN_DEFAULT = re.compile(r"^enum in \[(.*)\], default (.+)$")
+REGEX_MATCH_DATA_TYPE_ENUM_IN_DEFAULT = re.compile(r"^enum in \[(.*)\], default (.+)$")  # noqa # pylint: disable=C0301
 REGEX_MATCH_DATA_TYPE_ENUM_IN = re.compile(r"^enum in \[(.*)\](, \(.+\))*$")
-REGEX_MATCH_DATA_TYPE_SET_IN = re.compile(r"^enum set in \{(.*)\}(, \(.+\))*$")
-REGEX_MATCH_DATA_TYPE_BOOLEAN_DEFAULT = re.compile(r"^boolean, default (False|True)$")
-REGEX_MATCH_DATA_TYPE_BOOLEAN_ARRAY_OF = re.compile(r"^boolean array of ([0-9]+) items(, .+)*$")
-REGEX_MATCH_DATA_TYPE_MATHUTILS_VALUES = re.compile(r"^`((mathutils.)*(Color|Euler|Matrix|Quaternion|Vector))`$")
-REGEX_MATCH_DATA_TYPE_NUMBER_ARRAY_OF = re.compile(r"^(int|float) array of ([0-9]+) items in \[([-einf+0-9,. ]+)\](, .+)*$")
-REGEX_MATCH_DATA_TYPE_MATHUTILS_ARRAY_OF = re.compile(r"^`(mathutils.[a-zA-Z]+)` (rotation )*of ([0-9]+) items in \[([-einf+0-9,. ]+)\](, .+)*$")
-REGEX_MATCH_DATA_TYPE_NUMBER_IN = re.compile(r"^(int|float) in \[([-einf+0-9,. ]+)\](, .+)*$")
+REGEX_MATCH_DATA_TYPE_SET_IN = re.compile(r"^enum set in \{(.*)\}(, \(.+\))*$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_BOOLEAN_DEFAULT = re.compile(r"^boolean, default (False|True)$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_BOOLEAN_ARRAY_OF = re.compile(r"^boolean array of ([0-9]+) items(, .+)*$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_MATHUTILS_VALUES = re.compile(r"^`((mathutils.)*(Color|Euler|Matrix|Quaternion|Vector))`$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_NUMBER_ARRAY_OF = re.compile(r"^(int|float) array of ([0-9]+) items in \[([-einf+0-9,. ]+)\](, .+)*$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_MATHUTILS_ARRAY_OF = re.compile(r"^`(mathutils.[a-zA-Z]+)` (rotation )*of ([0-9]+) items in \[([-einf+0-9,. ]+)\](, .+)*$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_NUMBER_IN = re.compile(r"^(int|float) in \[([-einf+0-9,. ]+)\](, .+)*$")  # noqa # pylint: disable=C0301
 REGEX_MATCH_DATA_TYPE_ENDSWITH_NUMBER = re.compile(r"(int|float)$")
-REGEX_MATCH_DATA_TYPE_FLOAT_MULTI_DIMENSIONAL_ARRAY_OF = re.compile(r"^float multi-dimensional array of ([0-9]) \* ([0-9]) items in \[([-einf+0-9,. ]+)\](, .+)*$")
-REGEX_MATCH_DATA_TYPE_MATHUTILS_MATRIX_OF = re.compile(r"^`mathutils.Matrix` of ([0-9]) \* ([0-9]) items in \[([-einf+0-9,. ]+)\](, .+)*$")
+REGEX_MATCH_DATA_TYPE_FLOAT_MULTI_DIMENSIONAL_ARRAY_OF = re.compile(r"^float multi-dimensional array of ([0-9]) \* ([0-9]) items in \[([-einf+0-9,. ]+)\](, .+)*$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_MATHUTILS_MATRIX_OF = re.compile(r"^`mathutils.Matrix` of ([0-9]) \* ([0-9]) items in \[([-einf+0-9,. ]+)\](, .+)*$")  # noqa # pylint: disable=C0301
 REGEX_MATCH_DATA_TYPE_STRING = re.compile(r"^(str|string|strings|string)\.*$")
-REGEX_MATCH_DATA_TYPE_VALUE_BPY_PROP_COLLECTION_OF = re.compile(r"^`([a-zA-Z0-9]+)` `bpy_prop_collection` of `([a-zA-Z0-9]+)`, $")
-REGEX_MATCH_DATA_TYPE_SEQUENCE_OF = re.compile(r"^sequence of `([a-zA-Z0-9_.]+)`$")
-REGEX_MATCH_DATA_TYPE_BPY_PROP_COLLECTION_OF = re.compile(r"^`bpy_prop_collection` of `([a-zA-Z0-9]+)`, $")
-REGEX_MATCH_DATA_TYPE_LIST_OF_VALUE_OBJECTS = re.compile(r"^List of `([A-Za-z0-9]+)` objects$")
-REGEX_MATCH_DATA_TYPE_LIST_OF_VALUE = re.compile(r"^[Ll]ist of `([A-Za-z0-9_.]+)`$")
-REGEX_MATCH_DATA_TYPE_LIST_OF_NUMBER_OR_STRING = re.compile(r"^(list|sequence) of (float|int|str)")
-REGEX_MATCH_DATA_TYPE_LIST_OF_PARENTHESES_VALUE = re.compile(r"^list of \(([a-zA-Z.,` ]+)\)")
-REGEX_MATCH_DATA_TYPE_BMELEMSEQ_OF_VALUE = re.compile(r"`BMElemSeq` of `([a-zA-Z0-9]+)`$")
-REGEX_MATCH_DATA_TYPE_TUPLE_OF_VALUE = re.compile(r"^tuple of `([a-zA-Z0-9.]+)`('s)*$")
-REGEX_MATCH_DATA_TYPE_LIST_OR_DICT_OR_SET_OR_TUPLE = re.compile(r"^`*(list|dict|set|tuple)`*\.*$")
+REGEX_MATCH_DATA_TYPE_VALUE_BPY_PROP_COLLECTION_OF = re.compile(r"^`([a-zA-Z0-9]+)` `bpy_prop_collection` of `([a-zA-Z0-9]+)`, $")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_SEQUENCE_OF = re.compile(r"^sequence of `([a-zA-Z0-9_.]+)`$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_BPY_PROP_COLLECTION_OF = re.compile(r"^`bpy_prop_collection` of `([a-zA-Z0-9]+)`, $")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_LIST_OF_VALUE_OBJECTS = re.compile(r"^List of `([A-Za-z0-9]+)` objects$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_LIST_OF_VALUE = re.compile(r"^[Ll]ist of `([A-Za-z0-9_.]+)`$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_LIST_OF_NUMBER_OR_STRING = re.compile(r"^(list|sequence) of (float|int|str)")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_LIST_OF_PARENTHESES_VALUE = re.compile(r"^list of \(([a-zA-Z.,` ]+)\)")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_BMELEMSEQ_OF_VALUE = re.compile(r"`BMElemSeq` of `([a-zA-Z0-9]+)`$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_TUPLE_OF_VALUE = re.compile(r"^tuple of `([a-zA-Z0-9.]+)`('s)*$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_LIST_OR_DICT_OR_SET_OR_TUPLE = re.compile(r"^`*(list|dict|set|tuple)`*\.*$")  # noqa # pylint: disable=C0301
 REGEX_MATCH_DATA_TYPE_OT = re.compile(r"^`([A-Z]+)_OT_([A-Za-z_]+)`, $")
 REGEX_MATCH_DATA_TYPE_DOT = re.compile(r"^`([a-zA-Z0-9_]+\.[a-zA-Z0-9_.]+)`$")
 REGEX_MATCH_DATA_TYPE_DOT_COMMA = re.compile(r"^`([a-zA-Z0-9_.]+)`(, )*$")
 REGEX_MATCH_DATA_TYPE_NAME = re.compile(r"^[a-zA-Z0-9_.]+$")
-
-##
-#    :rtype: (list of `mathutils.Vector`, list of (int, int), list of list of int, list of list of int, list of list of int, list of list of int)
+# pylint: enable=line-too-long
 
 
 class DataTypeMetadata:
@@ -1422,7 +1422,7 @@ class DataTypeRefiner:
             if s:
                 return CustomDataType(s)
 
-        if dtype_str in ("type","object","function"):
+        if dtype_str in ("type", "object", "function"):
             return ModifierDataType("typing.Any")
 
         if dtype_str.startswith("Depends on function prototype"):
@@ -1436,7 +1436,7 @@ class DataTypeRefiner:
         if dtype_str.startswith("`AnyType`"):
             return ModifierDataType("typing.Any")
 
-        if dtype_str in ("any","Any type."):
+        if dtype_str in ("any", "Any type."):
             return ModifierDataType("typing.Any")
 
         # "[23][dD] [Vv]ector"
@@ -1572,7 +1572,7 @@ class DataTypeRefiner:
             return BuiltinDataType("int", ModifierDataType("typing.Sequence"))
 
         # Ex: float multi-dimensional array of 3 * 3 items in [-inf, inf]
-        if m := REGEX_MATCH_DATA_TYPE_FLOAT_MULTI_DIMENSIONAL_ARRAY_OF.match(dtype_str):
+        if m := REGEX_MATCH_DATA_TYPE_FLOAT_MULTI_DIMENSIONAL_ARRAY_OF.match(dtype_str):  # noqa # pylint: disable=C0301
             dtypes = [
                 BuiltinDataType("float", ModifierDataType("listlist")),
                 BuiltinDataType(
@@ -1617,7 +1617,7 @@ class DataTypeRefiner:
             if s1:
                 return CustomDataType(s1)
 
-        if m := REGEX_MATCH_DATA_TYPE_VALUE_BPY_PROP_COLLECTION_OF.match(dtype_str):
+        if m := REGEX_MATCH_DATA_TYPE_VALUE_BPY_PROP_COLLECTION_OF.match(dtype_str):  # noqa # pylint: disable=C0301
             s1 = self._parse_custom_data_type(
                 m.group(1), uniq_full_names, uniq_module_names, module_name)
             s2 = self._parse_custom_data_type(
@@ -1666,10 +1666,10 @@ class DataTypeRefiner:
             if s:
                 return CustomDataType(s, ModifierDataType("list"))
         # Ex: list of ints
-        if m := REGEX_MATCH_DATA_TYPE_LIST_OF_NUMBER_OR_STRING.match(dtype_str):
+        if m := REGEX_MATCH_DATA_TYPE_LIST_OF_NUMBER_OR_STRING.match(dtype_str):  # noqa # pylint: disable=C0301
             return BuiltinDataType(m.group(2), ModifierDataType("list"))
         # Ex: list of (bmesh.types.BMVert)
-        if m := REGEX_MATCH_DATA_TYPE_LIST_OF_PARENTHESES_VALUE.match(dtype_str):
+        if m := REGEX_MATCH_DATA_TYPE_LIST_OF_PARENTHESES_VALUE.match(dtype_str):  # noqa # pylint: disable=C0301
             items = m.group(1).split(",")
             dtypes = []
             for item in items:
@@ -1706,7 +1706,7 @@ class DataTypeRefiner:
                     skip_refine=True)
                 return dd
 
-        if dtype_str in ("BMVertSeq", "BMEdgeSeq", "BMFaceSeq", "BMLoopSeq", "BMEditSelSeq"):
+        if dtype_str in ("BMVertSeq", "BMEdgeSeq", "BMFaceSeq", "BMLoopSeq", "BMEditSelSeq"):  # noqa # pylint: disable=C0301
             s = self._parse_custom_data_type(
                 dtype_str, uniq_full_names, uniq_module_names, module_name)
             if s:
@@ -1720,7 +1720,7 @@ class DataTypeRefiner:
             return ModifierDataType("dict")
         if dtype_str == "iterable object":
             return ModifierDataType("list")
-        if m := REGEX_MATCH_DATA_TYPE_LIST_OR_DICT_OR_SET_OR_TUPLE.match(dtype_str):
+        if m := REGEX_MATCH_DATA_TYPE_LIST_OR_DICT_OR_SET_OR_TUPLE.match(dtype_str):  # noqa # pylint: disable=C0301
             return ModifierDataType(m.group(1))
 
         # Ex: bpy.types.Struct subclass


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

* Reduce the execution time of `gen.py`.

### Description about the pull request

* I profiled `gen.py` and found that compiling the regular expressions takes a long time.
    [profile_before.txt](https://github.com/nutti/fake-bpy-module/files/13893891/profile_before.txt)
    `817374612 function calls (815148474 primitive calls) in 308.347 seconds`
* Pre-compiling the regular expressions makes it 3.7 times faster.
    [profile_after.txt](https://github.com/nutti/fake-bpy-module/files/13893889/profile_after.txt)
    `126576412 function calls (126367374 primitive calls) in 82.795 seconds`
* Output results changed slightly. The change has not yet been checked.
    [results_diff.txt](https://github.com/nutti/fake-bpy-module/files/13893944/results_diff.txt)

    ```
    diff -ur build/results_original build/results > results_diff.txt
    ```