### PR TITLE
Fix references to old requirements.txt location

### DIFF
--- a/docs/generate_modules.md
+++ b/docs/generate_modules.md
@@ -19,13 +19,13 @@ Check your Python version is >= 3.8.
 ### Install requirement packages
 
 The generating script uses the packages listed on
-[requirements.txt](../requirements.txt).  
+[requirements.txt](../src/requirements.txt).  
 Execute below command to install requirement packages.
 
 ```bash
 git clone https://github.com/nutti/fake-bpy-module.git
 cd fake-bpy-module
-pip install -r requirements.txt
+pip install -r src/requirements.txt
 ```
 
 ### Setup IDE

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -30,6 +30,6 @@ RUN pip install pathlib
 RUN git clone https://git.blender.org/blender.git
 
 RUN git clone https://github.com/nutti/fake-bpy-module.git
-RUN pip install -r fake-bpy-module/requirements.txt
+RUN pip install -r fake-bpy-module/src/requirements.txt
 RUN bash fake-bpy-module/tools/utils/download_blender.sh all blender-bin
 RUN rm -rf fake-bpy-module


### PR DESCRIPTION
### Purpose of the pull request

0bc095e7a6cecd3df905a61a4b4fcfed53c77696 moved `requirements.txt` to `src/requirements.txt` but left some references to the old location, particularly in the documentation, which this pull request fixes.
