### PR TITLE
Fix missing 'target' parameters in build docs

### DIFF
--- a/docs/generate_modules.md
+++ b/docs/generate_modules.md
@@ -68,17 +68,18 @@ Or, you can download .zip file from GitHub.
 <!-- markdownlint-disable MD013 -->
 ```bash
 cd fake-bpy-module/src
-bash gen_module.sh <source-dir> <blender-dir> <branch/tag/commit> <blender-version> <output-dir> <mod-version>
+bash gen_module.sh <source-dir> <blender-dir> <target> <branch/tag/commit> <target-version> <output-dir> [<mod-version>]
 ```
 <!-- markdownlint-enable MD013 -->
 
 * `<source-dir>`: Specify Blender sources directory.
 * `<blender-dir>`: Specify Blender binary directory.
+* `<target>`: `blender` or `upbge`.
 * `<branch/tag/commit>`: Specify target Blender source's branch for the
   generating modules.
   * If you want to generate modules for 2.79, specify `v2.79`
   * If you want to generate modules for newest Blender version, specify `master`
-* `<blender-version>`: Specify blender version.
+* `<target-version>`: Specify target version.
 * `<output-dir>`: Specify directory where generated modules are output.
 * `<mod-version>`: Modify APIs by using patch files located in `mods` directory.
   * If you specify `2.80`, all patch files under `mods/2.80` will be used.
@@ -171,13 +172,11 @@ python gen_modfile/gen_bgl_modfile.py -i ${BLENDER_SRC}/source/blender/python/ge
 ```
 <!-- markdownlint-enable MD013 -->
 
-* `<blender-version>`: Specify Blender version.
-
 ### 7. Generate modules
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-python gen.py -i <input-dir> -o <output-dir> -f <format> -b <blender-version> -m <mod-version>
+python gen.py -i <input-dir> -o <output-dir> -f <format> -T <target> -t <target-version> -m <mod-version>
 ```
 <!-- markdownlint-enable MD013 -->
 
@@ -189,9 +188,11 @@ python gen.py -i <input-dir> -o <output-dir> -f <format> -b <blender-version> -m
 * `-d`: Dump internal data structures to `<output-dir>` as the files name with
   suffix `-dump.json`
 * `-f <format>`: Format the generated code by `<format>` convention.
+  * `none`: Don't format generated code.
   * `yapf`: Format generated code with yapf.
   * `ruff`: Format generated code with ruff.
-* `-b <blender-version>`: Specify blender version.
+* `-T <target>`: Target (`blender` or `upbge`).
+* `-t <target-version>`: Specify target version.
 * `-m <mod-version>`: Modify APIs by using patch files located in `mods` directory.
   * If you specify `2.80`, all patch files under `mods/2.80` will be used.
   * Files located in `mods/common` directories will be used at any time.


### PR DESCRIPTION
### Purpose of the pull request

c6338daa0b4b7464c39fc1ed1a9619d8f1e1bca1 added `target` parameters to a number of scripts, but the build documentation was not updated to match.

### Additional comments

I have not touched the docker section.