### PR TITLE
Fix incomplete fixes to build docs

### DIFF
--- a/docs/generate_modules.md
+++ b/docs/generate_modules.md
@@ -93,7 +93,7 @@ environment variable.
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-PYTHON_BIN=/path/to/python3.8 bash gen_module.sh <source-dir> <blender-dir> <branch/tag/commit> <output-dir> <mod-version>
+PYTHON_BIN=/path/to/python3.8 bash gen_module.sh <source-dir> <blender-dir> <target> <branch/tag/commit> <target-version> <output-dir> [<mod-version>]
 ```
 <!-- markdownlint-enable MD013 -->
 
@@ -119,7 +119,7 @@ export BLENDER_SRC=${WORKSPACE}/blender
 
 ```bash
 cd ${WORKSPACE}
-git clone git://git.blender.org/blender.git
+git clone https://projects.blender.org/blender/blender.git
 ```
 
 ### 3. Change to the target branch/tag/commit


### PR DESCRIPTION
I missed a second occurrence of `gen_module.sh` in 30152a68f8f795a681074d2af317d39c0d9612fb.

dc761c8e024dd61f03425ae79798eb6e425a2c6a missed a second occurrence of cloning `blender.git`.