### PR TITLE
Ignore src/gen_module-tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 
 # build files
 tests/tmp
+src/gen_module-tmp
 src/mods/generated_mods
 tools/pip_package/tmp-*
 /build/


### PR DESCRIPTION
In the case that `gen_module.sh` fails for some reason (e.g. #185) `src/gen_module-tmp` and `src/mods/generated_mods` are not removed, however only the latter was being ignored by git.