### PR TITLE
Use modern Python 3.10 syntax

### DIFF
--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -204,10 +204,7 @@ class PyCodeWriterBase(BaseWriter):
                         wt.addln(f":param {name_node.astext()}: {desc_node.astext()}")
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                        if len(dtype_nodes) >= 2:
-                            dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
-                        else:
-                            dtype_str = dtype_nodes[0].to_string()
+                        dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
@@ -222,10 +219,7 @@ class PyCodeWriterBase(BaseWriter):
                         wt.addln(f":return: {desc_node.astext()}")
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                        if len(dtype_nodes) >= 2:
-                            dtype = " | ".join(n.to_string() for n in dtype_nodes)
-                        else:
-                            dtype = dtype_nodes[0].to_string()
+                        dtype = " | ".join(n.to_string() for n in dtype_nodes)
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
@@ -280,10 +274,7 @@ class PyCodeWriterBase(BaseWriter):
                 dtype_str = None
                 if not dtype_list_node.empty():
                     dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                    if len(dtype_nodes) >= 2:
-                        dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
-                    else:
-                        dtype_str = dtype_nodes[0].to_string()
+                    dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
                     for dtype_node in dtype_nodes:
                         if "option" not in dtype_node.attributes:
                             continue
@@ -348,10 +339,7 @@ class PyCodeWriterBase(BaseWriter):
 
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                        if len(dtype_nodes) >= 2:
-                            dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
-                        else:
-                            dtype_str = dtype_nodes[0].to_string()
+                        dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
@@ -381,10 +369,7 @@ class PyCodeWriterBase(BaseWriter):
                     dtype_list_node = return_node.element(DataTypeListNode)
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                        if len(dtype_nodes) >= 2:
-                            dtype = " | ".join(n.to_string() for n in dtype_nodes)
-                        else:
-                            dtype = dtype_nodes[0].to_string()
+                        dtype = " | ".join(n.to_string() for n in dtype_nodes)
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
@@ -414,10 +399,7 @@ class PyCodeWriterBase(BaseWriter):
                             wt.addln(f":param {name_node.astext()}: {desc_node.astext()}")
                             if not dtype_list_node.empty():
                                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                                if len(dtype_nodes) >= 2:
-                                    dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
-                                else:
-                                    dtype_str = dtype_nodes[0].to_string()
+                                dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
                                 for dtype_node in dtype_nodes:
                                     if "option" not in dtype_node.attributes:
                                         continue
@@ -434,10 +416,7 @@ class PyCodeWriterBase(BaseWriter):
 
                             if not dtype_list_node.empty():
                                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                                if len(dtype_nodes) >= 2:
-                                    dtype = " | ".join(n.to_string() for n in dtype_nodes)
-                                else:
-                                    dtype = dtype_nodes[0].to_string()
+                                dtype = " | ".join(n.to_string() for n in dtype_nodes)
                                 for dtype_node in dtype_nodes:
                                     if "option" not in dtype_node.attributes:
                                         continue
@@ -465,10 +444,7 @@ class PyCodeWriterBase(BaseWriter):
 
         if not dtype_list_node.empty():
             dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-            if len(dtype_nodes) >= 2:
-                dtype = " | ".join(n.to_string() for n in dtype_nodes)
-            else:
-                dtype = dtype_nodes[0].to_string()
+            dtype = " | ".join(n.to_string() for n in dtype_nodes)
             for dtype_node in dtype_nodes:
                 if "option" not in dtype_node.attributes:
                     continue

--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -435,7 +435,7 @@ class PyCodeWriterBase(BaseWriter):
                             if not dtype_list_node.empty():
                                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                                 if len(dtype_nodes) >= 2:
-                                    dtype = f" | ".join(n.to_string() for n in dtype_nodes)
+                                    dtype = " | ".join(n.to_string() for n in dtype_nodes)
                                 else:
                                     dtype = dtype_nodes[0].to_string()
                                 for dtype_node in dtype_nodes:
@@ -466,7 +466,7 @@ class PyCodeWriterBase(BaseWriter):
         if not dtype_list_node.empty():
             dtype_nodes = find_children(dtype_list_node, DataTypeNode)
             if len(dtype_nodes) >= 2:
-                dtype = f" | ".join(n.to_string() for n in dtype_nodes)
+                dtype = " | ".join(n.to_string() for n in dtype_nodes)
             else:
                 dtype = dtype_nodes[0].to_string()
             for dtype_node in dtype_nodes:

--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -137,14 +137,14 @@ class PyCodeWriterBase(BaseWriter):
             if not dtype_list_node.empty():
                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                 if len(dtype_nodes) >= 2:
-                    dtype_str = f"typing.Union[{', '.join([n.to_string() for n in dtype_nodes])}]"
+                    dtype_str = ' | '.join(n.to_string() for n in dtype_nodes)
                 else:
                     dtype_str = dtype_nodes[0].to_string()
                 for dtype_node in dtype_nodes:
                     if "option" not in dtype_node.attributes:
                         continue
                     if "never none" not in dtype_node.attributes["option"]:
-                        dtype_str = f"typing.Optional[{dtype_str}]"
+                        dtype_str = f"{dtype_str} | None"
                         break
 
                 if not default_value_node.empty():
@@ -166,14 +166,14 @@ class PyCodeWriterBase(BaseWriter):
             if not dtype_list_node.empty():
                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                 if len(dtype_nodes) >= 2:
-                    dtype = f"typing.Union[{', '.join([n.to_string() for n in dtype_nodes])}]"
+                    dtype = ' | '.join(n.to_string() for n in dtype_nodes)
                 else:
                     dtype = dtype_nodes[0].to_string()
                 for dtype_node in dtype_nodes:
                     if "option" not in dtype_node.attributes:
                         continue
                     if "accept none" in dtype_node.attributes["option"]:
-                        dtype = f"typing.Optional[{dtype}]"
+                        dtype = f"{dtype} | None"
                         break
                 wt.addln(f") -> {dtype}:")
             else:
@@ -205,15 +205,14 @@ class PyCodeWriterBase(BaseWriter):
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                         if len(dtype_nodes) >= 2:
-                            dtype_str = ", ".join([n.to_string() for n in dtype_nodes])
-                            dtype_str = f"typing.Union[{dtype_str}]"
+                            dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
                         else:
                             dtype_str = dtype_nodes[0].to_string()
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
                             if "never none" not in dtype_node.attributes["option"]:
-                                dtype_str = f"typing.Optional[{dtype_str}]"
+                                dtype_str = f"{dtype_str} | None"
                                 break
                         wt.addln(f":type {name_node.astext()}: {dtype_str}")
                 if not return_node.empty():
@@ -224,15 +223,14 @@ class PyCodeWriterBase(BaseWriter):
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                         if len(dtype_nodes) >= 2:
-                            dtype_str = ", ".join([n.to_string() for n in dtype_nodes])
-                            dtype = f"typing.Union[{dtype_str}]"
+                            dtype = " | ".join(n.to_string() for n in dtype_nodes)
                         else:
                             dtype = dtype_nodes[0].to_string()
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
                             if "accept none" in dtype_node.attributes["option"]:
-                                dtype = f"typing.Optional[{dtype}]"
+                                dtype = f"{dtype} | None"
                                 break
                         wt.addln(f":rtype: {dtype}")
                 wt.addln("'''")
@@ -260,7 +258,7 @@ class PyCodeWriterBase(BaseWriter):
                 if not dtype_list_node.empty():
                     dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                     if len(dtype_nodes) >= 2:
-                        dtype = f"typing.Union[{', '.join([n.to_string() for n in dtype_nodes])}]"
+                        dtype = ' | '.join(n.to_string() for n in dtype_nodes)
                     else:
                         dtype = dtype_nodes[0].to_string()
                     dtypes.append(dtype)
@@ -283,8 +281,7 @@ class PyCodeWriterBase(BaseWriter):
                 if not dtype_list_node.empty():
                     dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                     if len(dtype_nodes) >= 2:
-                        dtype_str = ", ".join([n.to_string() for n in dtype_nodes])
-                        dtype_str = f"typing.Union[{dtype_str}]"
+                        dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
                     else:
                         dtype_str = dtype_nodes[0].to_string()
                     for dtype_node in dtype_nodes:
@@ -352,15 +349,14 @@ class PyCodeWriterBase(BaseWriter):
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                         if len(dtype_nodes) >= 2:
-                            dtype_str = ", ".join([n.to_string() for n in dtype_nodes])
-                            dtype_str = f"typing.Union[{dtype_str}]"
+                            dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
                         else:
                             dtype_str = dtype_nodes[0].to_string()
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
                             if "never none" not in dtype_node.attributes["option"]:
-                                dtype_str = f"typing.Optional[{dtype_str}]"
+                                dtype_str = f"{dtype_str} | None"
                                 break
 
                         if not default_value_node.empty():
@@ -386,15 +382,14 @@ class PyCodeWriterBase(BaseWriter):
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                         if len(dtype_nodes) >= 2:
-                            dtype_str = ", ".join([n.to_string() for n in dtype_nodes])
-                            dtype = f"typing.Union[{dtype_str}]"
+                            dtype = " | ".join(n.to_string() for n in dtype_nodes)
                         else:
                             dtype = dtype_nodes[0].to_string()
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
                             if "accept none" in dtype_node.attributes["option"]:
-                                dtype = f"typing.Optional[{dtype}]"
+                                dtype = f"{dtype} | None"
                                 break
                         wt.addln(f") -> {dtype}:")
                     else:
@@ -420,15 +415,14 @@ class PyCodeWriterBase(BaseWriter):
                             if not dtype_list_node.empty():
                                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                                 if len(dtype_nodes) >= 2:
-                                    dtype_str = ", ".join([n.to_string() for n in dtype_nodes])
-                                    dtype_str = f"typing.Union[{dtype_str}]"
+                                    dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
                                 else:
                                     dtype_str = dtype_nodes[0].to_string()
                                 for dtype_node in dtype_nodes:
                                     if "option" not in dtype_node.attributes:
                                         continue
                                     if "never none" not in dtype_node.attributes["option"]:
-                                        dtype_str = f"typing.Optional[{dtype_str}]"
+                                        dtype_str = f"{dtype_str} | None"
                                         break
                                 wt.addln(f":type {name_node.astext()}: {dtype_str}")
 
@@ -441,15 +435,14 @@ class PyCodeWriterBase(BaseWriter):
                             if not dtype_list_node.empty():
                                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
                                 if len(dtype_nodes) >= 2:
-                                    dtype_str = ", ".join([n.to_string() for n in dtype_nodes])
-                                    dtype = f"typing.Union[{dtype_str}]"
+                                    dtype = f" | ".join(n.to_string() for n in dtype_nodes)
                                 else:
                                     dtype = dtype_nodes[0].to_string()
                                 for dtype_node in dtype_nodes:
                                     if "option" not in dtype_node.attributes:
                                         continue
                                     if "accept none" in dtype_node.attributes["option"]:
-                                        dtype = f"typing.Optional[{dtype}]"
+                                        dtype = f"{dtype} | None"
                                         break
                                 wt.addln(f":rtype: {dtype}")
                         wt.addln("'''")
@@ -473,7 +466,7 @@ class PyCodeWriterBase(BaseWriter):
         if not dtype_list_node.empty():
             dtype_nodes = find_children(dtype_list_node, DataTypeNode)
             if len(dtype_nodes) >= 2:
-                dtype = f"typing.Union[{', '.join([n.to_string() for n in dtype_nodes])}]"
+                dtype = f" | ".join(n.to_string() for n in dtype_nodes)
             else:
                 dtype = dtype_nodes[0].to_string()
             for dtype_node in dtype_nodes:

--- a/src/fake_bpy_module/transformer/bpy_ops_override_parameters_adder.py
+++ b/src/fake_bpy_module/transformer/bpy_ops_override_parameters_adder.py
@@ -37,7 +37,7 @@ class BpyOpsOverrideParameterAdder(TransformerBase):
                     arg_node.element(DataTypeListNode).append_child(
                         make_data_type_node("`bpy.types.Context`"))
                     dtype_node = DataTypeNode()
-                    append_child(dtype_node, nodes.Text("typing.Dict[str, typing.Any]"))
+                    append_child(dtype_node, nodes.Text("dict[str, typing.Any]"))
                     dtype_node.attributes["mod-option"] = "skip-refine"
                     arg_node.element(DataTypeListNode).append_child(dtype_node)
                     arg_list_node.insert(0, arg_node)

--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -281,7 +281,7 @@ class DataTypeRefiner(TransformerBase):
                 f"tuple[{', '.join(['float'] * int(m.group(1)))}]"
             ] * int(m.group(2))
             return [
-                make_data_type_node("list[list[float]]"), 
+                make_data_type_node("list[list[float]]"),
                 make_data_type_node(f"tuple[{', '.join(tuple_elems)}]")
             ]
 

--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -147,7 +147,7 @@ class DataTypeRefiner(TransformerBase):
                 module_name)
             if s:
                 return [
-                    make_data_type_node("typing.List[typing.Callable[[`bpy.types.Scene`, None]]]")
+                    make_data_type_node("list[typing.Callable[[`bpy.types.Scene`, None]]]")
                 ]
 
         if dtype_str == "Same type with self class":
@@ -194,8 +194,8 @@ class DataTypeRefiner(TransformerBase):
 
         # Ex: enum set in {'KEYMAP_FALLBACK'}, (optional)
         if REGEX_MATCH_DATA_TYPE_SET_IN.match(dtype_str):
-            return [make_data_type_node("typing.Set[str]"),
-                    make_data_type_node("typing.Set[int]")]
+            return [make_data_type_node("set[str]"),
+                    make_data_type_node("set[int]")]
 
         # Ex: enum in :ref:`rna_enum_object_modifier_type_items`, (optional)
         if dtype_str.startswith("enum in `rna"):
@@ -203,15 +203,15 @@ class DataTypeRefiner(TransformerBase):
 
         # Ex: Enumerated constant
         if dtype_str == "Enumerated constant":
-            return [make_data_type_node("typing.Set[str]"),
-                    make_data_type_node("typing.Set[int]")]
+            return [make_data_type_node("set[str]"),
+                    make_data_type_node("set[int]")]
 
         # Ex: boolean, default False
         if REGEX_MATCH_DATA_TYPE_BOOLEAN_DEFAULT.match(dtype_str):
             return [make_data_type_node("bool")]
         # Ex: boolean array of 3 items, (optional)
         if REGEX_MATCH_DATA_TYPE_BOOLEAN_ARRAY_OF.match(dtype_str):
-            return [make_data_type_node("typing.List[bool]")]
+            return [make_data_type_node("list[bool]")]
 
         if dtype_str == "boolean":
             return [make_data_type_node("bool")]
@@ -250,8 +250,8 @@ class DataTypeRefiner(TransformerBase):
             if s:
                 tuple_elms = ["float"] * int(m.group(3))
                 return [
-                    make_data_type_node("typing.List[float]"),
-                    make_data_type_node(f"typing.Tuple[{', '.join(tuple_elms)}]"),
+                    make_data_type_node("list[float]"),
+                    make_data_type_node(f"tuple[{', '.join(tuple_elms)}]"),
                     make_data_type_node(f"`{s}`")
                 ]
 
@@ -278,11 +278,11 @@ class DataTypeRefiner(TransformerBase):
         # Ex: float multi-dimensional array of 3 * 3 items in [-inf, inf]
         if m := REGEX_MATCH_DATA_TYPE_FLOAT_MULTI_DIMENSIONAL_ARRAY_OF.match(dtype_str):  # noqa # pylint: disable=C0301
             tuple_elems = [
-                f"typing.Tuple[{', '.join(['float'] * int(m.group(1)))}]"
+                f"tuple[{', '.join(['float'] * int(m.group(1)))}]"
             ] * int(m.group(2))
             return [
-                make_data_type_node("typing.List[typing.List[float]]"),
-                make_data_type_node(f"typing.Tuple[{', '.join(tuple_elems)}]")
+                make_data_type_node("list[list[float]]"), 
+                make_data_type_node(f"tuple[{', '.join(tuple_elems)}]")
             ]
 
         if m := REGEX_MATCH_DATA_TYPE_MATHUTILS_MATRIX_OF.match(dtype_str):
@@ -291,11 +291,11 @@ class DataTypeRefiner(TransformerBase):
                 module_name)
             if s:
                 tuple_elems = [
-                    f"typing.Tuple[{', '.join(['float'] * int(m.group(1)))}]"
+                    f"tuple[{', '.join(['float'] * int(m.group(1)))}]"
                 ] * int(m.group(2))
                 return [
-                    make_data_type_node("typing.List[typing.List[float]]"),
-                    make_data_type_node(f"typing.Tuple[{', '.join(tuple_elems)}]"),
+                    make_data_type_node("list[list[float]]"),
+                    make_data_type_node(f"tuple[{', '.join(tuple_elems)}]"),
                     make_data_type_node(f"`{s}`")
                 ]
 
@@ -309,7 +309,7 @@ class DataTypeRefiner(TransformerBase):
         if REGEX_MATCH_DATA_TYPE_INTEGER.match(dtype_str):
             return [make_data_type_node("int")]
         if dtype_str == "tuple":
-            return [make_data_type_node("typing.Tuple")]
+            return [make_data_type_node("tuple")]
         if dtype_str == "sequence":
             return [make_data_type_node("typing.Sequence")]
 
@@ -328,7 +328,7 @@ class DataTypeRefiner(TransformerBase):
                 return [make_data_type_node(f"`{s1}`")]
 
         if dtype_str.startswith("set of strings"):
-            return [make_data_type_node("typing.Set[str]")]
+            return [make_data_type_node("set[str]")]
 
         # [Pattern] sequence of string tuples or a function
         # [Test]
@@ -358,16 +358,16 @@ class DataTypeRefiner(TransformerBase):
             s = self._parse_custom_data_type(
                 m.group(1), uniq_full_names, uniq_module_names, module_name)
             if s:
-                return [make_data_type_node(f"typing.List[`{s}`]")]
+                return [make_data_type_node(f"list[`{s}`]")]
         # Ex: list of FEdge
         if m := REGEX_MATCH_DATA_TYPE_LIST_OF_VALUE.match(dtype_str):
             s = self._parse_custom_data_type(
                 m.group(1), uniq_full_names, uniq_module_names, module_name)
             if s:
-                return [make_data_type_node(f"typing.List[`{s}`]")]
+                return [make_data_type_node(f"list[`{s}`]")]
         # Ex: list of ints
         if m := REGEX_MATCH_DATA_TYPE_LIST_OF_NUMBER_OR_STRING.match(dtype_str):  # noqa # pylint: disable=C0301
-            return [make_data_type_node(f"typing.List[{m.group(2)}]")]
+            return [make_data_type_node(f"list[{m.group(2)}]")]
         # Ex: list of (bmesh.types.BMVert)
         if m := REGEX_MATCH_DATA_TYPE_LIST_OF_PARENTHESES_VALUE.match(dtype_str):  # noqa # pylint: disable=C0301
             items = m.group(1).split(",")
@@ -379,7 +379,7 @@ class DataTypeRefiner(TransformerBase):
                         im.group(1), uniq_full_names, uniq_module_names,
                         module_name)
                     if s:
-                        dtypes.append(make_data_type_node(f"typing.List[`{s}`]"))
+                        dtypes.append(make_data_type_node(f"list[`{s}`]"))
             return dtypes
         # Ex: BMElemSeq of BMEdge
         if m := REGEX_MATCH_DATA_TYPE_BMELEMSEQ_OF_VALUE.match(dtype_str):
@@ -387,7 +387,7 @@ class DataTypeRefiner(TransformerBase):
                 m.group(1), uniq_full_names, uniq_module_names, module_name)
             if s:
                 return [
-                    make_data_type_node(f"typing.List[`{s}`]"),
+                    make_data_type_node(f"list[`{s}`]"),
                     make_data_type_node("`bmesh.types.BMElemSeq`")
                 ]
         # Ex: tuple of mathutils.Vector's
@@ -395,7 +395,7 @@ class DataTypeRefiner(TransformerBase):
             s = self._parse_custom_data_type(
                 m.group(1), uniq_full_names, uniq_module_names, module_name)
             if s:
-                return [make_data_type_node(f"typing.Tuple[`{s}`, ...]")]
+                return [make_data_type_node(f"tuple[`{s}`, ...]")]
 
         # Ex: (Vector, Quaternion, Vector)
         if m1 := REGEX_MATCH_DATA_TYPE_START_AND_END_WITH_PARENTHESES.match(dtype_str):
@@ -410,12 +410,12 @@ class DataTypeRefiner(TransformerBase):
                         dtypes.append(f"`{s}`")
             if len(dtypes) != 0:
                 elem_str = ", ".join(dtypes)
-                return [make_data_type_node(f"typing.Tuple[{elem_str}]")]
+                return [make_data_type_node(f"tuple[{elem_str}]")]
 
         if dtype_str == "dict with string keys":
-            return [make_data_type_node("typing.Dict[str, typing.Any]")]
+            return [make_data_type_node("dict[str, typing.Any]")]
         if dtype_str == "iterable object":
-            return [make_data_type_node("typing.List")]
+            return [make_data_type_node("list")]
         if m := REGEX_MATCH_DATA_TYPE_LIST_OR_DICT_OR_SET_OR_TUPLE.match(dtype_str):  # noqa # pylint: disable=C0301
             return [make_data_type_node(f"{m.group(1)}")]
 
@@ -548,7 +548,7 @@ class DataTypeRefiner(TransformerBase):
                     dtypes.extend(d)
             if len(dtypes) >= 1:
                 return [make_data_type_node(
-                    f"typing.Tuple[{', '.join([d.astext() for d in dtypes])}]")]
+                    f"tuple[{', '.join([d.astext() for d in dtypes])}]")]
 
         result = self._get_refined_data_type_fast(
             dtype_str, uniq_full_names, uniq_module_names, module_name,

--- a/src/fake_bpy_module/transformer/default_value_filler.py
+++ b/src/fake_bpy_module/transformer/default_value_filler.py
@@ -45,10 +45,10 @@ class DefaultValueFiller(TransformerBase):
                         "bytes": "0",
                         "float": "0.0",
                         "int": "0",
-                        "typing.List": "[]",
-                        "typing.Dict": "{}",
-                        "typing.Set": "()",
-                        "typing.Tuple": "()",
+                        "list": "[]",
+                        "dict": "{}",
+                        "set": "()",
+                        "tuple": "()",
                     }
                     if dtype in BUILTIN_DTYPE_DEFAULT_VALUE_MAP:
                         default_value_node.add_text(BUILTIN_DTYPE_DEFAULT_VALUE_MAP[dtype])
@@ -56,10 +56,10 @@ class DefaultValueFiller(TransformerBase):
 
                     # Modifier data type.
                     MODIFIER_DTYPE_DEFAULT_VALUE_MAP = {
-                        "typing.List": "[]",
-                        "typing.Dict": "{}",
-                        "typing.Set": "()",
-                        "typing.Tuple": "()",
+                        "list": "[]",
+                        "dict": "{}",
+                        "set": "()",
+                        "tuple": "()",
                         "Generic": "None",
                         "typing.Iterator": "[]",
                         "typing.Callable": "None",

--- a/src/mods/common/analyzer/append/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/append/bpy.types.mod.rst
@@ -36,21 +36,21 @@
 
    .. method:: __getitem__(key)
 
-      :type key: typing.Union[int, str, slice]
+      :type key: int | str | slice
       :mod-option arg key: skip-refine
       :rtype: GenericType
       :mod-option rtype: skip-refine
 
    .. method:: __setitem__(key, value)
 
-      :type key: typing.Union[int, str]
+      :type key: int | str
       :mod-option arg key: skip-refine
       :type value: GenericType
       :mod-option arg value: skip-refine
 
    .. method:: __delitem__(key)
 
-      :type key: typing.Union[int, str]
+      :type key: int | str
       :mod-option arg key: skip-refine
       :rtype: GenericType
       :mod-option rtype: skip-refine
@@ -84,21 +84,21 @@
 
    .. method:: __getitem__(key)
 
-      :type key: typing.Union[int, str]
+      :type key: int | str
       :mod-option arg key: skip-refine
       :rtype: typing.Any
       :mod-option rtype: skip-refine
 
    .. method:: __setitem__(key, value)
 
-      :type key: typing.Union[int, str]
+      :type key: int | str
       :mod-option arg key: skip-refine
       :type value: typing.Any
       :mod-option arg value: skip-refine
 
    .. method:: __delitem__(key)
 
-      :type key: typing.Union[int, str]
+      :type key: int | str
       :mod-option arg key: skip-refine
       :rtype: typing.Any
       :mod-option rtype: skip-refine

--- a/src/mods/common/analyzer/new/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/new/bpy.types.mod.rst
@@ -14,21 +14,21 @@
 
    .. method:: __getitem__(key)
 
-      :type key: typing.Union[int, str]
+      :type key: int | str
       :mod-option arg key: skip-refine
       :rtype: GenericType
       :mod-option rtype: skip-refine
 
    .. method:: __setitem__(key, value)
 
-      :type key: typing.Union[int, str]
+      :type key: int | str
       :mod-option arg key: skip-refine
       :type value: GenericType
       :mod-option arg value: skip-refine
 
    .. method:: __delitem__(key)
 
-      :type key: typing.Union[int, str]
+      :type key: int | str
       :mod-option arg key: skip-refine
       :rtype: GenericType
       :mod-option rtype: skip-refine

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/class/class.json
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/class/class.json
@@ -153,7 +153,7 @@
                         "description": "staticmethod_1 arg_2 description",
                         "data_types": [
                             {
-                                "data_type": "typing.Tuple",
+                                "data_type": "tuple",
                                 "options": {}
                             }
                         ],

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/class/class.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/class/class.xml
@@ -115,7 +115,7 @@
                             (0, 0)
                         <data-type-list>
                             <data-type>
-                                typing.Tuple
+                                tuple
                 <return>
                     <description>
                         staticmethod_1 return description

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/input/class/class.rst
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/input/class/class.rst
@@ -45,7 +45,7 @@
       :param arg_1: staticmethod_1 arg_1 description
       :type arg_1: float
       :arg arg_2: staticmethod_1 arg_2 description
-      :type arg_2: typing.Tuple
+      :type arg_2: tuple
       :return: staticmethod_1 return description
       :rtype: str
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/class/class.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/class/class.py
@@ -57,7 +57,7 @@ class ClassA:
         pass
 
     @typing.overload
-    def function_1(self, arg_1: float, arg_2: int) -> str | None: 
+    def function_1(self, arg_1: float, arg_2: int) -> str | None:
         """function_1 description
 
         :param arg_1: function_1 arg_1 description
@@ -65,6 +65,6 @@ class ClassA:
         :param arg_2: function_1 arg_2 description
         :type arg_2: int
         :return: function_1 return description
-        :rtype: str | None:
+        :rtype: str | None
         """
         pass

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/class/class.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/class/class.py
@@ -44,20 +44,20 @@ class ClassA:
         pass
 
     @staticmethod
-    def staticmethod_1(arg_1: float, arg_2: typing.Tuple = (0, 0)) -> str:
+    def staticmethod_1(arg_1: float, arg_2: tuple = (0, 0)) -> str:
         """staticmethod_1 description
 
         :param arg_1: staticmethod_1 arg_1 description
         :type arg_1: float
         :param arg_2: staticmethod_1 arg_2 description
-        :type arg_2: typing.Tuple
+        :type arg_2: tuple
         :return: staticmethod_1 return description
         :rtype: str
         """
         pass
 
     @typing.overload
-    def function_1(self, arg_1: float, arg_2: int) -> typing.Optional[str]:
+    def function_1(self, arg_1: float, arg_2: int) -> str | None: 
         """function_1 description
 
         :param arg_1: function_1 arg_1 description
@@ -65,6 +65,6 @@ class ClassA:
         :param arg_2: function_1 arg_2 description
         :type arg_2: int
         :return: function_1 return description
-        :rtype: typing.Optional[str]
+        :rtype: str | None:
         """
         pass

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/class/class.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/class/class.xml
@@ -115,7 +115,7 @@
                             (0, 0)
                         <data-type-list>
                             <data-type>
-                                typing.Tuple
+                                tuple
                 <return>
                     <description>
                         staticmethod_1 return description

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/function/function.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/function/function.py
@@ -19,11 +19,11 @@ def function_1(arg_1: float, arg_2: str = "test", arg_3: int = 1234) -> str:
     pass
 
 
-def function_2() -> typing.Optional[str]:
+def function_2() -> str | None:
     """
 
     :return: function_2 return description
-    :rtype: typing.Optional[str]
+    :rtype: str | None
     """
 
     pass

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/input/class/class.rst
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/input/class/class.rst
@@ -45,7 +45,7 @@
       :param arg_1: staticmethod_1 arg_1 description
       :type arg_1: float
       :arg arg_2: staticmethod_1 arg_2 description
-      :type arg_2: typing.Tuple
+      :type arg_2: tuple
       :return: staticmethod_1 return description
       :rtype: str
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/class/class.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/class/class.pyi
@@ -43,20 +43,20 @@ class ClassA:
         ...
 
     @staticmethod
-    def staticmethod_1(arg_1: float, arg_2: typing.Tuple = (0, 0)) -> str:
+    def staticmethod_1(arg_1: float, arg_2: tuple = (0, 0)) -> str:
         """staticmethod_1 description
 
         :param arg_1: staticmethod_1 arg_1 description
         :type arg_1: float
         :param arg_2: staticmethod_1 arg_2 description
-        :type arg_2: typing.Tuple
+        :type arg_2: tuple
         :return: staticmethod_1 return description
         :rtype: str
         """
         ...
 
     @typing.overload
-    def function_1(self, arg_1: float, arg_2: int) -> typing.Optional[str]:
+    def function_1(self, arg_1: float, arg_2: int) -> str | None:
         """function_1 description
 
         :param arg_1: function_1 arg_1 description
@@ -64,6 +64,6 @@ class ClassA:
         :param arg_2: function_1 arg_2 description
         :type arg_2: int
         :return: function_1 return description
-        :rtype: typing.Optional[str]
+        :rtype: str | None
         """
         ...

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/class/class.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/class/class.xml
@@ -115,7 +115,7 @@
                             (0, 0)
                         <data-type-list>
                             <data-type>
-                                typing.Tuple
+                                tuple
                 <return>
                     <description>
                         staticmethod_1 return description

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/function/function.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/function/function.pyi
@@ -17,11 +17,11 @@ def function_1(arg_1: float, arg_2: str = "test", arg_3: int = 1234) -> str:
 
     ...
 
-def function_2() -> typing.Optional[str]:
+def function_2() -> str | None:
     """
 
     :return: function_2 return description
-    :rtype: typing.Optional[str]
+    :rtype: str | None
     """
 
     ...

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/input/class/class.rst
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/input/class/class.rst
@@ -45,7 +45,7 @@
       :param arg_1: staticmethod_1 arg_1 description
       :type arg_1: float
       :arg arg_2: staticmethod_1 arg_2 description
-      :type arg_2: typing.Tuple
+      :type arg_2: tuple
       :return: staticmethod_1 return description
       :rtype: str
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/bpy_ops_override_parameters_adder_test/expect/basic_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/bpy_ops_override_parameters_adder_test/expect/basic_transformed.xml
@@ -22,7 +22,7 @@
                         <class-ref>
                             bpy.types.Context
                     <data-type mod-option="skip-refine">
-                        typing.Dict[str, typing.Any]
+                        dict[str, typing.Any]
             <argument argument_type="arg">
                 <name>
                     execution_context
@@ -70,7 +70,7 @@
                         <class-ref>
                             bpy.types.Context
                     <data-type mod-option="skip-refine">
-                        typing.Dict[str, typing.Any]
+                        dict[str, typing.Any]
             <argument argument_type="arg">
                 <name>
                     execution_context

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/special_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/special_data_type_transformed.xml
@@ -11,7 +11,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Tuple[
+                tuple[
                 <class-ref>
                     module_1.ClassA
                 , 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
@@ -18,7 +18,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List[typing.Callable[[
+                list[typing.Callable[[
                 <class-ref>
                     bpy.types.Scene
                 , None]]]
@@ -126,9 +126,9 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Set[str]
+                set[str]
             <data-type option="never none">
-                typing.Set[int]
+                set[int]
     <data>
         <name>
             data_enum_in_rna
@@ -144,9 +144,9 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Set[str]
+                set[str]
             <data-type option="never none">
-                typing.Set[int]
+                set[int]
     <data>
         <name>
             data_boolean_default
@@ -160,7 +160,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List[bool]
+                list[bool]
     <data>
         <name>
             data_boolean
@@ -237,9 +237,9 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List[float]
+                list[float]
             <data-type option="never none">
-                typing.Tuple[float, float, float]
+                tuple[float, float, float]
             <data-type option="never none">
                 <class-ref>
                     mathutils.Vector
@@ -301,18 +301,18 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List[typing.List[float]]
+                list[list[float]]
             <data-type option="never none">
-                typing.Tuple[typing.Tuple[float, float, float], typing.Tuple[float, float, float], typing.Tuple[float, float, float]]
+                tuple[tuple[float, float, float], tuple[float, float, float], tuple[float, float, float]]
     <data>
         <name>
             data_mathutils_matrix_of
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List[typing.List[float]]
+                list[list[float]]
             <data-type option="never none">
-                typing.Tuple[typing.Tuple[float, float, float], typing.Tuple[float, float, float], typing.Tuple[float, float, float]]
+                tuple[tuple[float, float, float], tuple[float, float, float], tuple[float, float, float]]
             <data-type option="never none">
                 <class-ref>
                     mathutils.Matrix
@@ -350,7 +350,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Tuple
+                tuple
     <data>
         <name>
             data_sequence
@@ -380,7 +380,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Set[str]
+                set[str]
     <data>
         <name>
             data_sequence_of_string_tuples_or_a_function
@@ -418,7 +418,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List[
+                list[
                 <class-ref>
                     refined_module_a.RefinedClassA
                 ]
@@ -428,7 +428,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List[
+                list[
                 <class-ref>
                     refined_module_a.RefinedClassA
                 ]
@@ -438,19 +438,19 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List[float]
+                list[float]
     <data>
         <name>
             data_list_of_parentheses_value
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List[
+                list[
                 <class-ref>
                     refined_module_a.RefinedClassA
                 ]
             <data-type option="never none">
-                typing.List[
+                list[
                 <class-ref>
                     module_1.ClassA
                 ]
@@ -460,7 +460,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List[
+                list[
                 <class-ref>
                     refined_module_a.RefinedClassA
                 ]
@@ -473,7 +473,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Tuple[
+                tuple[
                 <class-ref>
                     refined_module_a.RefinedClassA
                 , ...]
@@ -483,14 +483,14 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Dict[str, typing.Any]
+                dict[str, typing.Any]
     <data>
         <name>
             data_iterable_object
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.List
+                list
     <data>
         <name>
             data_list
@@ -573,7 +573,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Tuple[
+                tuple[
                 <class-ref>
                     refined_module_a.RefinedClassA
                 , 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic.xml
@@ -57,7 +57,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.List
+                        list
             <argument argument_type="arg">
                 <name>
                     arg_dict
@@ -65,7 +65,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Dict
+                        dict
             <argument argument_type="arg">
                 <name>
                     arg_set
@@ -73,7 +73,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Set
+                        set
             <argument argument_type="arg">
                 <name>
                     arg_tuple
@@ -81,7 +81,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Tuple
+                        tuple
         <return>
             <description>
             <data-type-list>
@@ -97,7 +97,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.List[int]
+                        list[int]
             <argument argument_type="arg">
                 <name>
                     arg_dict
@@ -105,7 +105,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Dict[str, int]
+                        dict[str, int]
             <argument argument_type="arg">
                 <name>
                     arg_set
@@ -113,7 +113,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Set[int]
+                        set[int]
             <argument argument_type="arg">
                 <name>
                     arg_tuple
@@ -121,7 +121,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Tuple[int, float, int]
+                        tuple[int, float, int]
             <argument argument_type="arg">
                 <name>
                     arg_generic

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic_transformed.xml
@@ -63,7 +63,7 @@
                     []
                 <data-type-list>
                     <data-type option="optional">
-                        typing.List
+                        list
             <argument argument_type="arg">
                 <name>
                     arg_dict
@@ -72,7 +72,7 @@
                     {}
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Dict
+                        dict
             <argument argument_type="arg">
                 <name>
                     arg_set
@@ -81,7 +81,7 @@
                     ()
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Set
+                        set
             <argument argument_type="arg">
                 <name>
                     arg_tuple
@@ -90,7 +90,7 @@
                     ()
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Tuple
+                        tuple
         <return>
             <description>
             <data-type-list>
@@ -107,7 +107,7 @@
                     []
                 <data-type-list>
                     <data-type option="optional">
-                        typing.List[int]
+                        list[int]
             <argument argument_type="arg">
                 <name>
                     arg_dict
@@ -116,7 +116,7 @@
                     {}
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Dict[str, int]
+                        dict[str, int]
             <argument argument_type="arg">
                 <name>
                     arg_set
@@ -125,7 +125,7 @@
                     ()
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Set[int]
+                        set[int]
             <argument argument_type="arg">
                 <name>
                     arg_tuple
@@ -134,7 +134,7 @@
                     ()
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Tuple[int, float, int]
+                        tuple[int, float, int]
             <argument argument_type="arg">
                 <name>
                     arg_generic

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/input/basic.rst
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/input/basic.rst
@@ -13,24 +13,24 @@
    :option arg arg_float: optional
    :type arg_int: int
    :option arg arg_int: optional
-   :type arg_list: typing.List
+   :type arg_list: list
    :option arg arg_list: optional
-   :type arg_dict: typing.Dict
+   :type arg_dict: dict
    :option arg arg_dict: optional
-   :type arg_set: typing.Set
+   :type arg_set: set
    :option arg arg_set: optional
-   :type arg_tuple: typing.Tuple
+   :type arg_tuple: tuple
    :option arg arg_tuple: optional
 
 .. function:: modifier(arg_list, arg_dict, arg_set, arg_tuple, arg_generic, arg_iterator, arg_callable, arg_any, arg_sequence)
 
-   :type arg_list: typing.List[int]
+   :type arg_list: list[int]
    :option arg arg_list: optional
-   :type arg_dict: typing.Dict[str, int]
+   :type arg_dict: dict[str, int]
    :option arg arg_dict: optional
-   :type arg_set: typing.Set[int]
+   :type arg_set: set[int]
    :option arg arg_set: optional
-   :type arg_tuple: typing.Tuple[int, float, int]
+   :type arg_tuple: tuple[int, float, int]
    :option arg arg_tuple: optional
    :type arg_generic: Generic[Type]
    :option arg arg_generic: optional


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

This pull-request modernize the syntax used in the generated pyi files.

### Description about the pull request

- [x] PEP 585
- [x] PEP 604
- [ ] ~PEP 695~

