### PR TITLE
Update Python Version for local gen_module

### DIFF
--- a/docs/generate_modules.md
+++ b/docs/generate_modules.md
@@ -203,7 +203,7 @@ python gen.py -i <input-dir> -o <output-dir> -f <format> -T <target> -t <target-
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-bash tools/gen_module/run_gen_module.sh <blender-version>
+bash tools/gen_module/run_gen_module_in_docker.sh <blender-version>
 ```
 <!-- markdownlint-enable MD013 -->
 

--- a/tools/gen_module/Dockerfile
+++ b/tools/gen_module/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-bullseye
+FROM python:3.9-bullseye
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y \

--- a/tools/gen_module/Dockerfile
+++ b/tools/gen_module/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-bullseye
+FROM python:3.10-bullseye
 
 RUN apt-get update \
  && apt-get install --no-install-recommends -y \


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

Due to the update of the Python version from 3.8 to 3.9 in GitHub Actions dependencies in commit 782a482d4eb5e48ab932cc0e3d60fcbbcb435a72, we need to update the Python version locally to align with the GitHub Actions environment.

### Description about the pull request

- Update the Python version in `tools/gen_module/Dockerfile` from 3.8 to 3.9.
- Correct the incorrect script file name in `docs/generate_modules.md`.