### PR TITLE
Fix: remove extra quotes from set default value

### DIFF
--- a/src/fake_bpy_module/analyzer/directives.py
+++ b/src/fake_bpy_module/analyzer/directives.py
@@ -103,15 +103,35 @@ def parse_func_arg_default_value(expr: ast.expr):
     if isinstance(expr, ast.Name):
         return "None"   # TODO: Should be "expr.id"
     if isinstance(expr, ast.List):
-        return [parse_func_arg_default_value(e) for e in expr.elts]
+        return (
+            f"""[{', '.join(str(parse_func_arg_default_value(e))
+            for e in expr.elts)}]"""
+            if len(expr.elts) > 0
+            else "[]"
+        )
     if isinstance(expr, ast.Tuple):
-        return tuple((parse_func_arg_default_value(e) for e in expr.elts))
+        return (
+            f"""({', '.join(str(parse_func_arg_default_value(e))
+            for e in expr.elts)})"""
+            if len(expr.elts) > 0
+            else "()"
+        )
     if isinstance(expr, ast.Set):
-        return {parse_func_arg_default_value(e) for e in expr.elts}
+        return (
+            f"""{{{', '.join(str(parse_func_arg_default_value(e))
+            for e in expr.elts)}}}"""
+            if len(expr.elts) > 0
+            else "set()"
+        )
     if isinstance(expr, ast.Dict):
-        return {
-            parse_func_arg_default_value(k): parse_func_arg_default_value(v)
-            for k, v in zip(expr.keys, expr.values)}
+        return (
+            f"""{{{', '.join(
+            f'{parse_func_arg_default_value(k)}'
+            f':{parse_func_arg_default_value(v)}'
+            for k, v in zip(expr.keys, expr.values))}}}"""
+            if len(expr.keys) > 0
+            else "{}"
+        )
     if isinstance(expr, ast.UnaryOp):
         if isinstance(expr.op, ast.USub):
             operand = parse_func_arg_default_value(expr.operand)


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

- Fix #210
- Fix #209 

### Description about the pull request

To solve the issues above, I manually convert to string `set` but also `list`, `tuple`, and `dict` as they could have the same problem of extra quotes.

### Additional comments** [Optional]
