### PR TITLE
Fix: generate only needed py.typed

### DIFF
--- a/src/fake_bpy_module/generator/generator.py
+++ b/src/fake_bpy_module/generator/generator.py
@@ -24,10 +24,11 @@ def generate(documents: List[nodes.document]):
         dir_path = config.get_output_dir() + "/" + target_filename[:target_filename.rfind("/")]
         pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
 
-        # Create py.typed file.
-        filename = f"{dir_path}/py.typed"
-        with open(filename, "w", encoding="utf-8", newline="\n") as file:
-            file.write("")
+        # Create py.typed file at the root of modules.
+        if target_filename.count("/") == 1:
+            filename = f"{dir_path}/py.typed"
+            with open(filename, "w", encoding="utf-8", newline="\n") as file:
+                file.write("")
 
     # Generate modules.
     generator: BaseWriter = None


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

- Fix #167

### Description about the pull request

Count the number of `/` to determine if the module level to only generate `py.typed` files at the root of packages.