### PR TITLE
Fix: use str only for enum types instead of str|int

### DIFF
--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -188,24 +188,22 @@ class DataTypeRefiner(TransformerBase):
                 return [make_data_type_node(f"`{s}`")]
 
         if REGEX_MATCH_DATA_TYPE_ENUM_IN_DEFAULT.match(dtype_str):
-            return [make_data_type_node("str"), make_data_type_node("int")]
+            return [make_data_type_node("str")]
         # Ex: enum in ['POINT', 'EDGE', 'FACE', 'CORNER', 'CURVE', 'INSTANCE']
         if REGEX_MATCH_DATA_TYPE_ENUM_IN.match(dtype_str):
-            return [make_data_type_node("str"), make_data_type_node("int")]
+            return [make_data_type_node("str")]
 
         # Ex: enum set in {'KEYMAP_FALLBACK'}, (optional)
         if REGEX_MATCH_DATA_TYPE_SET_IN.match(dtype_str):
-            return [make_data_type_node("set[str]"),
-                    make_data_type_node("set[int]")]
+            return [make_data_type_node("set[str]")]
 
         # Ex: enum in :ref:`rna_enum_object_modifier_type_items`, (optional)
         if dtype_str.startswith("enum in `rna"):
-            return [make_data_type_node("str"), make_data_type_node("int")]
+            return [make_data_type_node("str")]
 
         # Ex: Enumerated constant
         if dtype_str == "Enumerated constant":
-            return [make_data_type_node("set[str]"),
-                    make_data_type_node("set[int]")]
+            return [make_data_type_node("set[str]")]
 
         # Ex: boolean, default False
         if REGEX_MATCH_DATA_TYPE_BOOLEAN_DEFAULT.match(dtype_str):

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
@@ -109,8 +109,6 @@
         <data-type-list>
             <data-type option="never none">
                 str
-            <data-type option="never none">
-                int
     <data>
         <name>
             data_enum_in
@@ -118,8 +116,6 @@
         <data-type-list>
             <data-type option="never none">
                 str
-            <data-type option="never none">
-                int
     <data>
         <name>
             data_set_in
@@ -127,8 +123,6 @@
         <data-type-list>
             <data-type option="never none">
                 set[str]
-            <data-type option="never none">
-                set[int]
     <data>
         <name>
             data_enum_in_rna
@@ -136,8 +130,6 @@
         <data-type-list>
             <data-type option="never none">
                 str
-            <data-type option="never none">
-                int
     <data>
         <name>
             data_enumerated_constant
@@ -145,8 +137,6 @@
         <data-type-list>
             <data-type option="never none">
                 set[str]
-            <data-type option="never none">
-                set[int]
     <data>
         <name>
             data_boolean_default


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

- Fix #213 
