### PR TITLE
Format code with Ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,25 @@ jobs:
       - name: pylint test
         run: bash tests/lint/pylint/run.sh .
 
+  ruff:
+    name: ruff
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: "pip"
+
+      - name: Install required pip packages
+        run: pip3 install ruff==0.4.5
+
+      - name: ruff format check
+        run: ruff format --check .
+
   markdownlint:
     name: markdownlint
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,10 @@ platforms = ["Windows", "Linux", "Mac OS-X"]
 
 [tool.setuptools.packages.find]
 where = ["."]
+
+[tool.ruff]
+target-version = "py39"
+line-length = 88
+
+[tool.ruff.format]
+quote-style = "preserve"

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,13 @@ from setuptools import setup
 
 # release version
 if "RELEASE_VERSION" in os.environ:
-    print("Environment variable 'RELEASE_VERSION' exists, "
-          "so use it as release version")
+    print("Environment variable 'RELEASE_VERSION' exists, so use it as release version")
     release_version = os.environ["RELEASE_VERSION"]
 else:
-    print("Environment variable 'RELEASE_VERSION' does not exist, "
-          "so use date as release version")
+    print(
+        "Environment variable 'RELEASE_VERSION' does not exist, "
+        "so use date as release version"
+    )
     release_version = datetime.datetime.today().strftime("%Y%m%d")
 
 setup(

--- a/src/fake_bpy_module/analyzer/analyzer.py
+++ b/src/fake_bpy_module/analyzer/analyzer.py
@@ -40,8 +40,10 @@ class BaseAnalyzer:
         }
 
         document: nodes.document = publish_doctree(
-            contents, settings_overrides=settings_overrides,
-            reader=readers.BpyRstDocsReader())
+            contents,
+            settings_overrides=settings_overrides,
+            reader=readers.BpyRstDocsReader(),
+        )
 
         document.insert(0, SourceFilenameNode(text=os.path.basename(filename)))
 

--- a/src/fake_bpy_module/analyzer/directives.py
+++ b/src/fake_bpy_module/analyzer/directives.py
@@ -101,7 +101,7 @@ def parse_func_arg_default_value(expr: ast.expr):
             return "None"
         return expr.value
     if isinstance(expr, ast.Name):
-        return "None"   # TODO: Should be "expr.id"
+        return "None"  # TODO: Should be "expr.id"
     if isinstance(expr, ast.List):
         return (
             f"""[{', '.join(str(parse_func_arg_default_value(e))
@@ -136,28 +136,26 @@ def parse_func_arg_default_value(expr: ast.expr):
         if isinstance(expr.op, ast.USub):
             operand = parse_func_arg_default_value(expr.operand)
             if isinstance(operand, (float, int)):
-                return -operand     # pylint: disable=E1130
+                return -operand  # pylint: disable=E1130
             if isinstance(operand, str):
                 return "None"
             raise NotImplementedError(
-                f"{type(operand)} is not supported as an operand of USub")
-        raise NotImplementedError(
-            f"{type(expr.op)} is not supported as an UnaryOp")
+                f"{type(operand)} is not supported as an operand of USub"
+            )
+        raise NotImplementedError(f"{type(expr.op)} is not supported as an UnaryOp")
     if isinstance(expr, ast.BinOp):
-        return "None"   # TODO: Should return result
+        return "None"  # TODO: Should return result
     if isinstance(expr, ast.Subscript):
         value = parse_func_arg_default_value(expr.value)
         slice_ = parse_func_arg_default_value(expr.slice)
         return f"{value}[{slice_}]"
     if isinstance(expr, ast.Call):
         func = parse_func_arg_default_value(expr.func)
-        args = ', '.join([str(parse_func_arg_default_value(arg))
-                          for arg in expr.args])
+        args = ', '.join([str(parse_func_arg_default_value(arg)) for arg in expr.args])
         return f"{func}({args})"
     if isinstance(expr, ast.Attribute):
-        return "None"   # TODO: Should be "expr.attr"
-    raise NotImplementedError(
-        f"{type(expr)} is not supported as a default value")
+        return "None"  # TODO: Should be "expr.attr"
+    raise NotImplementedError(f"{type(expr)} is not supported as a default value")
 
 
 def build_function_node_from_def(fdef: str) -> FunctionNode:
@@ -177,8 +175,7 @@ def build_function_node_from_def(fdef: str) -> FunctionNode:
             continue
         arg_node = ArgumentNode.create_template(argument_type="arg")
         arg_node.element(NameNode).add_text(arg.arg)
-        default_start = \
-            len(func_def.args.args) - len(func_def.args.defaults)
+        default_start = len(func_def.args.args) - len(func_def.args.defaults)
         if i >= default_start:
             default = func_def.args.defaults[i - default_start]
             default_value = parse_func_arg_default_value(default)
@@ -229,8 +226,7 @@ class ModuleDirective(rst.Directive):
 
     def run(self):
         paragraph_node = nodes.paragraph()
-        self.state.nested_parse(
-            self.content, self.content_offset, paragraph_node)
+        self.state.nested_parse(self.content, self.content_offset, paragraph_node)
 
         module_node = ModuleNode.create_template()
 
@@ -239,12 +235,12 @@ class ModuleDirective(rst.Directive):
         if config.get_target() == "blender":
             if config.get_target_version() == "2.90":
                 if module_name.startswith("bpy.types."):
-                    module_name = module_name[:module_name.rfind(".")]
+                    module_name = module_name[: module_name.rfind(".")]
             elif config.get_target_version() in [
                     "2.91", "2.92", "2.93",
                     "3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6",
                     "4.0", "4.1",
-                    "latest"]:
+                    "latest"]:  # fmt: skip
                 if module_name == "bpy.data":
                     module_name = "bpy"
         module_node.element(NameNode).add_text(module_name)
@@ -269,8 +265,7 @@ class ClassDirective(rst.Directive):
 
     def run(self):
         paragraph_node = nodes.paragraph()
-        self.state.nested_parse(
-            self.content, self.content_offset, paragraph_node)
+        self.state.nested_parse(self.content, self.content_offset, paragraph_node)
 
         class_node = ClassNode.create_template()
         class_name = self.arguments[0]
@@ -379,7 +374,8 @@ class FunctionDirective(rst.Directive):
     _ARG_FIELD_REGEX = re.compile(r"(arg|param|type)\s+([0-9a-zA-Z_]+)")
     _RETURN_FIELD_REGEX = re.compile(r"(return|rtype)")
     _OPTION_MODOPTION_FIELD_REFEX = re.compile(
-        r"(mod-option|option)\s+(arg|rtype|function)\s*(\S*)")
+        r"(mod-option|option)\s+(arg|rtype|function)\s*(\S*)"
+    )
 
     def run(self):
         paragraph: nodes.paragraph = nodes.paragraph()
@@ -446,18 +442,24 @@ class FunctionDirective(rst.Directive):
                                 break
                         if arg_node:
                             if m.group(1) in ("arg", "param"):
-                                arg_node.element(DescriptionNode).add_text(fbody_node.astext())
+                                arg_node.element(DescriptionNode).add_text(
+                                    fbody_node.astext()
+                                )
                             elif m.group(1) == "type":
                                 dtype = parse_data_type(fbody_node)
                                 arg_node.element(DataTypeListNode).append_child(dtype)
                     elif m := self._RETURN_FIELD_REGEX.match(fname_node.astext()):
                         func_ret_node = func_node.element(FunctionReturnNode)
                         if m.group(1) == "return":
-                            func_ret_node.element(DescriptionNode).add_text(fbody_node.astext())
+                            func_ret_node.element(DescriptionNode).add_text(
+                                fbody_node.astext()
+                            )
                         elif m.group(1) == "rtype":
                             dtype = parse_data_type(fbody_node)
                             func_ret_node.element(DataTypeListNode).append_child(dtype)
-                    elif m := self._OPTION_MODOPTION_FIELD_REFEX.match(fname_node.astext()):
+                    elif m := self._OPTION_MODOPTION_FIELD_REFEX.match(
+                        fname_node.astext()
+                    ):
                         if m.group(2) == "arg":
                             arg_name = m.group(3)
                             arg_node: ArgumentNode = None
@@ -468,7 +470,9 @@ class FunctionDirective(rst.Directive):
                                     break
                             if arg_node:
                                 for dtype_node in arg_node.findall(DataTypeNode):
-                                    dtype_node.attributes[m.group(1)] = fbody_node.astext()
+                                    dtype_node.attributes[m.group(1)] = (
+                                        fbody_node.astext()
+                                    )
                         elif m.group(2) == "rtype":
                             func_ret_node = func_node.element(FunctionReturnNode)
                             for dtype_node in func_ret_node.findall(DataTypeNode):
@@ -498,9 +502,7 @@ class LiteralIncludeDirective(rst.Directive):
     required_arguments = 1
     final_argument_whitespace = True
     has_content = True
-    option_spec = {
-        "lines": rst.directives.unchanged
-    }
+    option_spec = {"lines": rst.directives.unchanged}
 
     def run(self):
         path: str = self.arguments[0]
@@ -546,7 +548,9 @@ class BaseClassDirective(rst.Directive):
 
         for sp in base_classes.split(", "):
             base_class_node = BaseClassNode.create_template()
-            base_class_node.element(DataTypeListNode).append_child(make_data_type_node(sp))
+            base_class_node.element(DataTypeListNode).append_child(
+                make_data_type_node(sp)
+            )
             base_class_list_node.append_child(base_class_node)
 
         field_lists: nodes.field_list = paragraph.findall(nodes.field_list)
@@ -575,8 +579,7 @@ def register_directives():
     rst.directives.register_directive("data", DataDirective)
     rst.directives.register_directive("DATA", DataDirective)
 
-    rst.directives.register_directive(
-        "literalinclude", LiteralIncludeDirective)
+    rst.directives.register_directive("literalinclude", LiteralIncludeDirective)
     rst.directives.register_directive("seealso", DocumentDirective)
     rst.directives.register_directive("hlist", DocumentDirective)
     rst.directives.register_directive("toctree", DocumentDirective)

--- a/src/fake_bpy_module/analyzer/nodes.py
+++ b/src/fake_bpy_module/analyzer/nodes.py
@@ -14,8 +14,7 @@ class NodeBase(nodes.Element):
 
 class UniqueElementNode(NodeBase):
     # pylint: disable=W1113
-    def __init__(self, rawsource: str = "", *children: nodes.Node,
-                 **attributes):
+    def __init__(self, rawsource: str = "", *children: nodes.Node, **attributes):
         super().__init__(rawsource, *children, **attributes)
 
         self.elements = {}
@@ -118,8 +117,9 @@ class DataNode(UniqueElementNode, nodes.Part):
 
     # pylint: disable=W1113
     @classmethod
-    def create_template(cls, rawsource: str = "", *children: nodes.Node,
-                        **attributes) -> "DataNode":
+    def create_template(
+        cls, rawsource: str = "", *children: nodes.Node, **attributes
+    ) -> "DataNode":
         node = DataNode(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
@@ -135,8 +135,9 @@ class AttributeNode(DataNode):
 
     # pylint: disable=W1113
     @classmethod
-    def create_template(cls, rawsource: str = "", *children: nodes.Node,
-                        **attributes) -> "AttributeNode":
+    def create_template(
+        cls, rawsource: str = "", *children: nodes.Node, **attributes
+    ) -> "AttributeNode":
         node = AttributeNode(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
@@ -165,8 +166,9 @@ class ArgumentNode(UniqueElementNode, nodes.Part):
 
     # pylint: disable=W1113
     @classmethod
-    def create_template(cls, rawsource: str = "", *children: nodes.Node,
-                        **attributes) -> "ArgumentNode":
+    def create_template(
+        cls, rawsource: str = "", *children: nodes.Node, **attributes
+    ) -> "ArgumentNode":
         node = ArgumentNode(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
@@ -183,8 +185,9 @@ class FunctionReturnNode(UniqueElementNode, nodes.Part):
 
     # pylint: disable=W1113
     @classmethod
-    def create_template(cls, rawsource: str = "", *children: nodes.Node,
-                        **attributes) -> "FunctionReturnNode":
+    def create_template(
+        cls, rawsource: str = "", *children: nodes.Node, **attributes
+    ) -> "FunctionReturnNode":
         node = FunctionReturnNode(rawsource, *children, **attributes)
 
         node.append_child(DescriptionNode())
@@ -205,8 +208,9 @@ class FunctionNode(UniqueElementNode, nodes.Part):
 
     # pylint: disable=W1113
     @classmethod
-    def create_template(cls, rawsource: str = "", *children: nodes.Node,
-                        **attributes) -> "FunctionNode":
+    def create_template(
+        cls, rawsource: str = "", *children: nodes.Node, **attributes
+    ) -> "FunctionNode":
         node = FunctionNode(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
@@ -228,8 +232,9 @@ class BaseClassNode(UniqueElementNode, nodes.Part):
 
     # pylint: disable=W1113
     @classmethod
-    def create_template(cls, rawsource: str = "", *children: nodes.Node,
-                        **attributes) -> "BaseClassNode":
+    def create_template(
+        cls, rawsource: str = "", *children: nodes.Node, **attributes
+    ) -> "BaseClassNode":
         node = BaseClassNode(rawsource, *children, **attributes)
 
         node.append_child(DataTypeListNode())
@@ -243,8 +248,9 @@ class ClassNode(UniqueElementNode, nodes.Part):
 
     # pylint: disable=W1113
     @classmethod
-    def create_template(cls, rawsource: str = "", *children: nodes.Node,
-                        **attributes) -> "ClassNode":
+    def create_template(
+        cls, rawsource: str = "", *children: nodes.Node, **attributes
+    ) -> "ClassNode":
         node = ClassNode(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
@@ -262,8 +268,9 @@ class ModuleNode(UniqueElementNode, nodes.Part):
 
     # pylint: disable=W1113
     @classmethod
-    def create_template(cls, rawsource: str = "", *children: nodes.Node,
-                        **attributes) -> "ModuleNode":
+    def create_template(
+        cls, rawsource: str = "", *children: nodes.Node, **attributes
+    ) -> "ModuleNode":
         node = ModuleNode(rawsource, *children, **attributes)
 
         node.append_child(NameNode())

--- a/src/fake_bpy_module/analyzer/roles.py
+++ b/src/fake_bpy_module/analyzer/roles.py
@@ -62,6 +62,8 @@ def register_roles():
 
     roles.register_local_role("exc", roles.GenericRole("exc", OtherRef))
     roles.register_local_role("kbd", roles.GenericRole("kbd", OtherRef))
-    roles.register_local_role("menuselection", roles.GenericRole("menuselection", OtherRef))
+    roles.register_local_role(
+        "menuselection", roles.GenericRole("menuselection", OtherRef)
+    )
     roles.register_local_role("abbr", roles.GenericRole("abbr", OtherRef))
     roles.register_local_role("doc", roles.GenericRole("doc", OtherRef))

--- a/src/fake_bpy_module/generator/code_writer.py
+++ b/src/fake_bpy_module/generator/code_writer.py
@@ -85,18 +85,21 @@ class CodeWriter:
 
     def format(self, style_config: str, file_format: str):
         if style_config == "yapf":
-            self._code_data = io.StringIO(FormatCode(
-                self._code_data.getvalue(), style_config="pep8")[0])
+            self._code_data = io.StringIO(
+                FormatCode(self._code_data.getvalue(), style_config="pep8")[0]
+            )
         elif style_config == "ruff":
-            self._code_data = io.StringIO(subprocess.check_output(
-                [
-                    "ruff",
-                    "format",
-                    "--isolated",
-                    f"--stdin-filename=_.{file_format}",
-                ],
-                input=self._code_data.getvalue().encode(),
-            ).decode())
+            self._code_data = io.StringIO(
+                subprocess.check_output(
+                    [
+                        "ruff",
+                        "format",
+                        "--isolated",
+                        f"--stdin-filename=_.{file_format}",
+                    ],
+                    input=self._code_data.getvalue().encode(),
+                ).decode()
+            )
         elif style_config == "none":
             pass
         else:

--- a/src/fake_bpy_module/generator/generator.py
+++ b/src/fake_bpy_module/generator/generator.py
@@ -21,7 +21,11 @@ def generate(documents: List[nodes.document]):
     # Create module directories.
     for doc in documents:
         target_filename = get_first_child(doc, TargetFileNode).astext()
-        dir_path = config.get_output_dir() + "/" + target_filename[:target_filename.rfind("/")]
+        dir_path = (
+            config.get_output_dir()
+            + "/"
+            + target_filename[: target_filename.rfind("/")]
+        )
         pathlib.Path(dir_path).mkdir(parents=True, exist_ok=True)
 
         # Create py.typed file at the root of modules.
@@ -41,5 +45,8 @@ def generate(documents: List[nodes.document]):
 
     for doc in documents:
         target_filename = get_first_child(doc, TargetFileNode).astext()
-        generator.write(f"{config.get_output_dir()}/{target_filename}",
-                        doc, config.get_style_format())
+        generator.write(
+            f"{config.get_output_dir()}/{target_filename}",
+            doc,
+            config.get_style_format(),
+        )

--- a/src/fake_bpy_module/generator/translator.py
+++ b/src/fake_bpy_module/generator/translator.py
@@ -86,7 +86,13 @@ class CodeDocumentNodeTranslator(nodes.SparseNodeVisitor):
         new_line_num = 0
         if len(self.status_stack) >= 1:
             status = self.status_stack[-1]
-            if status.kind in ('BULLET_LIST', 'ENUMERATED_LIST', 'NOTE', 'WARNING', 'BLOCK_QUOTE'):
+            if status.kind in (
+                'BULLET_LIST',
+                'ENUMERATED_LIST',
+                'NOTE',
+                'WARNING',
+                'BLOCK_QUOTE',
+            ):
                 new_line_num = 1
         else:
             new_line_num = 2
@@ -114,7 +120,9 @@ class CodeDocumentNodeTranslator(nodes.SparseNodeVisitor):
 
     def visit_enumerated_list(self, _: nodes.enumerated_list):
         level = self.get_list_level()
-        self.status_stack.append(Status('ENUMERATED_LIST', {"number": 0, "level": level}))
+        self.status_stack.append(
+            Status('ENUMERATED_LIST', {"number": 0, "level": level})
+        )
 
     def depart_enumerated_list(self, _: nodes.enumerated_list):
         status = self.status_stack.pop()

--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -51,8 +51,9 @@ def sorted_entry_point_nodes(document: nodes.document) -> List[NodeBase]:
     all_function_nodes.extend(find_children(document, FunctionNode))
     all_data_nodes.extend(find_children(document, DataNode))
 
-    all_class_nodes = all_high_priority_class_nodes \
-        + sorted(all_class_nodes, key=lambda n: n.element(NameNode).astext())
+    all_class_nodes = all_high_priority_class_nodes + sorted(
+        all_class_nodes, key=lambda n: n.element(NameNode).astext()
+    )
 
     # Sort class data (with class inheritance dependencies)
     class_name_to_node = OrderedDict()
@@ -83,11 +84,13 @@ def sorted_entry_point_nodes(document: nodes.document) -> List[NodeBase]:
 
     # Sort function data
     sorted_function_nodes = sorted(
-        all_function_nodes, key=lambda n: n.element(NameNode).astext())
+        all_function_nodes, key=lambda n: n.element(NameNode).astext()
+    )
 
     # Sort constant data
     sorted_constant_nodes = sorted(
-        all_data_nodes, key=lambda n: n.element(NameNode).astext())
+        all_data_nodes, key=lambda n: n.element(NameNode).astext()
+    )
 
     # Merge
     sorted_nodes = sorted_class_nodes
@@ -102,7 +105,9 @@ class BaseWriter(metaclass=abc.ABCMeta):
         self.file_format = ""
 
     @abc.abstractmethod
-    def write(self, filename: str, document: nodes.document, style_config: str = 'ruff'):
+    def write(
+        self, filename: str, document: nodes.document, style_config: str = 'ruff'
+    ):
         raise NotImplementedError()
 
 
@@ -116,7 +121,7 @@ class PyCodeWriterBase(BaseWriter):
             "function": "pass",
             "attribute": " = None",
             "method": "pass",
-            "class": "pass"
+            "class": "pass",
         }
         self.file_format = "py"
 
@@ -294,11 +299,15 @@ class PyCodeWriterBase(BaseWriter):
                             break
 
                 if dtype_str is not None:
-                    wt.addln(f"{name_node.astext()}: {dtype_str}"
-                             f"{self.ellipsis_strings['attribute']}")
+                    wt.addln(
+                        f"{name_node.astext()}: {dtype_str}"
+                        f"{self.ellipsis_strings['attribute']}"
+                    )
                 else:
-                    wt.addln(f"{name_node.astext()}: typing.Any"
-                             f"{self.ellipsis_strings['attribute']}")
+                    wt.addln(
+                        f"{name_node.astext()}: typing.Any"
+                        f"{self.ellipsis_strings['attribute']}"
+                    )
 
                 if (not desc_node.empty()) or (dtype_str is not None):
                     wt.add("''' ")
@@ -370,14 +379,15 @@ class PyCodeWriterBase(BaseWriter):
                                 break
 
                         if not default_value_node.empty():
-                            wt.add(f"{arg_name}: {dtype_str}="
-                                   f"{default_value_node.astext()}")
+                            wt.add(
+                                f"{arg_name}: {dtype_str}="
+                                f"{default_value_node.astext()}"
+                            )
                         else:
                             wt.add(f"{arg_name}: {dtype_str}")
                     else:
                         if not default_value_node.empty():
-                            wt.add(f"{arg_name}="
-                                   f"{default_value_node.astext()}")
+                            wt.add(f"{arg_name}=" f"{default_value_node.astext()}")
                         else:
                             wt.add(arg_name)
 
@@ -418,14 +428,23 @@ class PyCodeWriterBase(BaseWriter):
                             name_node = arg_node.element(NameNode)
                             desc_node = arg_node.element(DescriptionNode)
                             dtype_list_node = arg_node.element(DataTypeListNode)
-                            wt.addln(f":param {name_node.astext()}: {desc_node.astext()}")
+                            wt.addln(
+                                f":param {name_node.astext()}: {desc_node.astext()}"
+                            )
                             if not dtype_list_node.empty():
-                                dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                                dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
+                                dtype_nodes = find_children(
+                                    dtype_list_node, DataTypeNode
+                                )
+                                dtype_str = " | ".join(
+                                    n.to_string() for n in dtype_nodes
+                                )
                                 for dtype_node in dtype_nodes:
                                     if "option" not in dtype_node.attributes:
                                         continue
-                                    if "never none" not in dtype_node.attributes["option"]:
+                                    if (
+                                        "never none"
+                                        not in dtype_node.attributes["option"]
+                                    ):
                                         dtype_str = f"{dtype_str} | None"
                                         break
                                 wt.addln(f":type {name_node.astext()}: {dtype_str}")
@@ -437,7 +456,9 @@ class PyCodeWriterBase(BaseWriter):
                             wt.addln(f":return: {desc_node.astext()}")
 
                             if not dtype_list_node.empty():
-                                dtype_nodes = find_children(dtype_list_node, DataTypeNode)
+                                dtype_nodes = find_children(
+                                    dtype_list_node, DataTypeNode
+                                )
                                 dtype = " | ".join(n.to_string() for n in dtype_nodes)
                                 for dtype_node in dtype_nodes:
                                     if "option" not in dtype_node.attributes:
@@ -473,23 +494,29 @@ class PyCodeWriterBase(BaseWriter):
                 if "accept none" in dtype_node.attributes["option"]:
                     dtype = f"{dtype} | None"
                     break
-            wt.addln(f"{name_node.astext()}: {dtype}"
-                     f"{self.ellipsis_strings['constant']}")
+            wt.addln(
+                f"{name_node.astext()}: {dtype}" f"{self.ellipsis_strings['constant']}"
+            )
         else:
-            wt.addln(f"{name_node.astext()}: typing.Any"
-                     f"{self.ellipsis_strings['constant']}")
+            wt.addln(
+                f"{name_node.astext()}: typing.Any"
+                f"{self.ellipsis_strings['constant']}"
+            )
         if not desc_node.empty():
             wt.addln(f"''' {remove_unencodable(desc_node.astext())}")
             wt.addln("'''")
         wt.new_line(2)
 
-    def write(self, filename: str, document: nodes.document, style_config: str = 'ruff'):
+    def write(
+        self, filename: str, document: nodes.document, style_config: str = 'ruff'
+    ):
         # At first, sort data to avoid generating large diff.
         # Note: Base class must be located above derived class
         sorted_data = sorted_entry_point_nodes(document)
 
-        with open(f"{filename}.{self.file_format}", "w",
-                  encoding="utf-8", newline="\n") as file:
+        with open(
+            f"{filename}.{self.file_format}", "w", encoding="utf-8", newline="\n"
+        ) as file:
             wt = self._writer
             wt.reset()
 
@@ -555,7 +582,7 @@ class PyCodeWriter(PyCodeWriterBase):
             "function": "pass",
             "attribute": " = None",
             "method": "pass",
-            "class": "pass"
+            "class": "pass",
         }
         self.file_format = "py"
 
@@ -569,7 +596,7 @@ class PyInterfaceWriter(PyCodeWriterBase):
             "function": "...",
             "attribute": "",
             "method": "...",
-            "class": "..."
+            "class": "...",
         }
         self.file_format = "pyi"
 
@@ -606,9 +633,11 @@ class JsonWriter(BaseWriter):
                 "name": arg_node.element(NameNode).astext(),
                 "description": arg_node.element(DescriptionNode).astext(),
                 "data_types": [],
-                "default_value": arg_node.element(DefaultValueNode).astext()
+                "default_value": arg_node.element(DefaultValueNode).astext(),
             }
-            dtype_nodes = find_children(arg_node.element(DataTypeListNode), DataTypeNode)
+            dtype_nodes = find_children(
+                arg_node.element(DataTypeListNode), DataTypeNode
+            )
             for dtype_node in dtype_nodes:
                 dtype_data = {
                     "data_type": dtype_node.to_string(),
@@ -662,12 +691,16 @@ class JsonWriter(BaseWriter):
             "options": self._clean_node_attributes(class_node.attributes),
         }
 
-        base_class_nodes = find_children(class_node.element(BaseClassListNode), BaseClassNode)
+        base_class_nodes = find_children(
+            class_node.element(BaseClassListNode), BaseClassNode
+        )
         for base_class_node in base_class_nodes:
             base_class_data = {
                 "data_types": [],
             }
-            dtype_nodes = find_children(base_class_node.element(DataTypeListNode), DataTypeNode)
+            dtype_nodes = find_children(
+                base_class_node.element(DataTypeListNode), DataTypeNode
+            )
             for dtype_node in dtype_nodes:
                 dtype_data = {
                     "data_type": dtype_node.to_string(),
@@ -690,7 +723,9 @@ class JsonWriter(BaseWriter):
 
         return class_data
 
-    def write(self, filename: str, document: nodes.document, style_config: str = 'none'):
+    def write(
+        self, filename: str, document: nodes.document, style_config: str = 'none'
+    ):
         sorted_data = sorted_entry_point_nodes(document)
 
         json_data = []
@@ -700,16 +735,20 @@ class JsonWriter(BaseWriter):
         visitor = CodeDocumentNodeTranslator(document, doc_writer)
         for node in code_doc_nodes:
             node.walkabout(visitor)
-        json_data.append({
-            "type": "code-document",
-            "contents": doc_writer.get_data_as_string(),
-        })
+        json_data.append(
+            {
+                "type": "code-document",
+                "contents": doc_writer.get_data_as_string(),
+            }
+        )
 
         # import external depended modules
-        json_data.append({
-            "type": "external-depended-modules",
-            "contents": ["typing", "collections.abc"],
-        })
+        json_data.append(
+            {
+                "type": "external-depended-modules",
+                "contents": ["typing", "collections.abc"],
+            }
+        )
 
         # import depended modules
         dep_list_node = get_first_child(document, DependencyListNode)
@@ -717,10 +756,12 @@ class JsonWriter(BaseWriter):
         if dep_list_node is not None:
             dep_nodes = find_children(dep_list_node, DependencyNode)
             dependencies = [node.astext() for node in dep_nodes]
-        json_data.append({
-            "type": "internal-depended-modules",
-            "contents": dependencies,
-        })
+        json_data.append(
+            {
+                "type": "internal-depended-modules",
+                "contents": dependencies,
+            }
+        )
 
         # import child module to search child modules
         child_list_node = get_first_child(document, ChildModuleListNode)
@@ -728,19 +769,23 @@ class JsonWriter(BaseWriter):
         if child_list_node is not None:
             child_nodes = find_children(child_list_node, ChildModuleNode)
             children = [node.astext() for node in child_nodes]
-        json_data.append({
-            "type": "child-modules",
-            "contents": children,
-        })
+        json_data.append(
+            {
+                "type": "child-modules",
+                "contents": children,
+            }
+        )
 
         # for generic type
-        json_data.append({
-            "type": "code",
-            "contents": [
-                'GenericType1 = typing.TypeVar("GenericType1")',
-                'GenericType2 = typing.TypeVar("GenericType2")',
-            ]
-        })
+        json_data.append(
+            {
+                "type": "code",
+                "contents": [
+                    'GenericType1 = typing.TypeVar("GenericType1")',
+                    'GenericType2 = typing.TypeVar("GenericType2")',
+                ],
+            }
+        )
 
         for node in sorted_data:
             if isinstance(node, ClassNode):
@@ -750,5 +795,7 @@ class JsonWriter(BaseWriter):
             elif isinstance(node, DataNode):
                 json_data.append(self._create_constant_json_data(node))
 
-        with open(f"{filename}.{self.file_format}", "w", newline="\n", encoding="utf-8") as f:
+        with open(
+            f"{filename}.{self.file_format}", "w", newline="\n", encoding="utf-8"
+        ) as f:
             json.dump(json_data, f, indent=4)

--- a/src/fake_bpy_module/support.py
+++ b/src/fake_bpy_module/support.py
@@ -1,15 +1,8 @@
 from typing import List
 
-SUPPORTED_TARGET: List[str] = [
-    "blender",
-    "upbge"
-]
+SUPPORTED_TARGET: List[str] = ["blender", "upbge"]
 
-SUPPORTED_STYLE_FORMAT: List[str] = [
-    "none",
-    "yapf",
-    "ruff"
-]
+SUPPORTED_STYLE_FORMAT: List[str] = ["none", "yapf", "ruff"]
 
 SUPPORTED_MOD_BLENDER_VERSION: List[str] = [
     "2.78", "2.79",
@@ -18,12 +11,9 @@ SUPPORTED_MOD_BLENDER_VERSION: List[str] = [
     "3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6",
     "4.0", "4.1",
     "latest"
-]
+]  # fmt: skip
 
-SUPPORTED_MOD_UPBGE_VERSION: List[str] = [
-    "0.2.5",
-    "latest"
-]
+SUPPORTED_MOD_UPBGE_VERSION: List[str] = ["0.2.5", "latest"]
 
 SUPPORTED_BLENDER_VERSION: List[str] = [
     "2.78", "2.79",
@@ -32,9 +22,6 @@ SUPPORTED_BLENDER_VERSION: List[str] = [
     "3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6",
     "4.0", "4.1",
     "latest"
-]
+]  # fmt: skip
 
-SUPPORTED_UPBGE_VERSION: List[str] = [
-    "0.2.5",
-    "latest"
-]
+SUPPORTED_UPBGE_VERSION: List[str] = ["0.2.5", "latest"]

--- a/src/fake_bpy_module/transformer/base_class_fixture.py
+++ b/src/fake_bpy_module/transformer/base_class_fixture.py
@@ -48,7 +48,8 @@ class BaseClassFixture(TransformerBase):
                     for bc in base_classes:
                         base_class_node = BaseClassNode.create_template()
                         base_class_node.element(DataTypeListNode).append_child(
-                            DataTypeNode(text=bc))
+                            DataTypeNode(text=bc)
+                        )
                         base_class_list_node.append_child(base_class_node)
 
                 para.parent.remove(para)

--- a/src/fake_bpy_module/transformer/bpy_context_variable_converter.py
+++ b/src/fake_bpy_module/transformer/bpy_context_variable_converter.py
@@ -11,7 +11,13 @@ from ..analyzer.nodes import (
     AttributeNode,
     make_data_type_node,
 )
-from ..utils import append_child, get_first_child, find_children, output_log, LOG_LEVEL_WARN
+from ..utils import (
+    append_child,
+    get_first_child,
+    find_children,
+    output_log,
+    LOG_LEVEL_WARN,
+)
 
 
 class BpyContextVariableConverter(TransformerBase):
@@ -24,9 +30,11 @@ class BpyContextVariableConverter(TransformerBase):
         bpy_context_module_document: nodes.document = None
         bpy_context_class_node: ClassNode = None
         for document in self.documents:
-            if (bpy_module_document is not None and
-                    bpy_context_module_document is not None and
-                    bpy_context_class_node is not None):
+            if (
+                bpy_module_document is not None
+                and bpy_context_module_document is not None
+                and bpy_context_class_node is not None
+            ):
                 break
 
             module_node = get_first_child(document, ModuleNode)
@@ -73,5 +81,7 @@ class BpyContextVariableConverter(TransformerBase):
         # Add the context variable to the bpy module.
         data_node = DataNode.create_template()
         data_node.element(NameNode).add_text("context")
-        data_node.element(DataTypeListNode).append_child(make_data_type_node("`bpy.types.Context`"))
+        data_node.element(DataTypeListNode).append_child(
+            make_data_type_node("`bpy.types.Context`")
+        )
         append_child(bpy_module_document, data_node)

--- a/src/fake_bpy_module/transformer/bpy_module_tweaker.py
+++ b/src/fake_bpy_module/transformer/bpy_module_tweaker.py
@@ -32,7 +32,6 @@ from ..utils import (
 
 
 class BpyModuleTweaker(TransformerBase):
-
     def _make_bpy_prop_functions_arguments_kwonlyargs(self, document: nodes.document):
         module_name = get_first_child(document, ModuleNode).element(NameNode).astext()
         if module_name != "bpy.props":
@@ -57,7 +56,8 @@ class BpyModuleTweaker(TransformerBase):
                 continue
             data_type_list_node = data_node.element(DataTypeListNode)
             data_type_list_node.insert(
-                0, make_data_type_node("list of callable[`bpy.types.Scene`]"))
+                0, make_data_type_node("list of callable[`bpy.types.Scene`]")
+            )
 
     def _add_bpy_ops_override_parameters(self, document: nodes.document):
         module_name = get_first_child(document, ModuleNode).element(NameNode).astext()
@@ -77,7 +77,8 @@ class BpyModuleTweaker(TransformerBase):
             arg_node.element(NameNode).add_text("override_context")
             arg_node.element(DefaultValueNode).add_text("None")
             arg_node.element(DataTypeListNode).append_child(
-                make_data_type_node("`bpy.types.Context`"))
+                make_data_type_node("`bpy.types.Context`")
+            )
             dtype_node = DataTypeNode()
             append_child(dtype_node, nodes.Text("dict[str, typing.Any]"))
             dtype_node.attributes["mod-option"] = "skip-refine"
@@ -88,14 +89,14 @@ class BpyModuleTweaker(TransformerBase):
             arg_node.element(NameNode).add_text("execution_context")
             arg_node.element(DefaultValueNode).add_text("None")
             arg_node.element(DataTypeListNode).append_child(
-                make_data_type_node("str, int"))
+                make_data_type_node("str, int")
+            )
             arg_list_node.insert(1, arg_node)
 
             arg_node = ArgumentNode.create_template(argument_type="arg")
             arg_node.element(NameNode).add_text("undo")
             arg_node.element(DefaultValueNode).add_text("None")
-            arg_node.element(DataTypeListNode).append_child(
-                make_data_type_node("bool"))
+            arg_node.element(DataTypeListNode).append_child(make_data_type_node("bool"))
             arg_list_node.insert(2, arg_node)
 
     def _rebase_bpy_types_class_base_class(self, document: nodes.document):
@@ -118,26 +119,29 @@ class BpyModuleTweaker(TransformerBase):
                 for dtype_node in dtype_nodes:
                     dtype_str = dtype_node.astext()
                     if m := re.match(
-                            r"^`([a-zA-Z0-9]+)` `bpy_prop_collection` of `"
-                            r"([a-zA-Z0-9]+)`, \(readonly\)$", dtype_str):
+                        r"^`([a-zA-Z0-9]+)` `bpy_prop_collection` of `"
+                        r"([a-zA-Z0-9]+)`, \(readonly\)$",
+                        dtype_str,
+                    ):
                         parent_to_child[m.group(1)] = m.group(2)
 
         for parent, child in parent_to_child.items():
             if parent == child:
-                output_log(
-                    LOG_LEVEL_WARN, f"Parent and child is same ({parent})")
+                output_log(LOG_LEVEL_WARN, f"Parent and child is same ({parent})")
                 continue
             output_log(
                 LOG_LEVEL_DEBUG,
-                f"Inheritance changed (Parent: {parent}, Child: {child})")
+                f"Inheritance changed (Parent: {parent}, Child: {child})",
+            )
 
             class_node = class_name_to_class_node[parent]
             bc_list_node = class_node.element(BaseClassListNode)
 
             bc_node = BaseClassNode.create_template()
             dtype_list_node = bc_node.element(DataTypeListNode)
-            dtype_list_node.append_child(make_data_type_node(
-                f"`bpy_prop_collection` of `{child}`, (readonly)"))
+            dtype_list_node.append_child(
+                make_data_type_node(f"`bpy_prop_collection` of `{child}`, (readonly)")
+            )
             bc_list_node.append_child(bc_node)
 
     def _apply(self, document: nodes.document):

--- a/src/fake_bpy_module/transformer/cannonical_data_type_rewriter.py
+++ b/src/fake_bpy_module/transformer/cannonical_data_type_rewriter.py
@@ -17,7 +17,6 @@ from .utils import get_base_name, get_module_name, build_module_structure
 
 
 class CannonicalDataTypeRewriter(TransformerBase):
-
     def __init__(self, documents: List[nodes.document], **kwargs):
         super().__init__(documents, **kwargs)
 
@@ -31,13 +30,11 @@ class CannonicalDataTypeRewriter(TransformerBase):
 
         ensured = f"{mod_name}.{base_name}"
         if ensured != data_type:
-            raise RuntimeError(
-                f"Invalid data type: ({data_type} vs {ensured})")
+            raise RuntimeError(f"Invalid data type: ({data_type} vs {ensured})")
 
         return ensured
 
-    def _get_generation_data_type(self, data_type: str,
-                                  target_module: str) -> str:
+    def _get_generation_data_type(self, data_type: str, target_module: str) -> str:
         mod_names_full_1 = get_module_name(data_type, self._package_structure)
         mod_names_full_2 = target_module
 
@@ -96,15 +93,15 @@ class CannonicalDataTypeRewriter(TransformerBase):
             else:
                 raise RuntimeError(
                     f"Should not reach this condition. ({rest_level_1} vs "
-                    f"{rest_level_2})")
+                    f"{rest_level_2})"
+                )
 
         return final_data_type
 
     def _rewrite(self, document: nodes.document):
         def rewrite(class_ref: ClassRef, module_name: str) -> ClassRef:
             class_name = class_ref.to_string()
-            new_class_name = self._get_generation_data_type(
-                class_name, module_name)
+            new_class_name = self._get_generation_data_type(class_name, module_name)
             new_class_ref = ClassRef(text=new_class_name)
             return new_class_ref
 

--- a/src/fake_bpy_module/transformer/code_document_refiner.py
+++ b/src/fake_bpy_module/transformer/code_document_refiner.py
@@ -22,9 +22,13 @@ class CodeDocumentRefiner(TransformerBase):
         para_nodes = find_children(new_doc_node, nodes.paragraph)
         nodes_to_remove: List[nodes.Node] = []
         for node in para_nodes:
-            if node.astext() in ("Inherited Functions", "Inherited Properties", "References"):
+            if node.astext() in (
+                "Inherited Functions",
+                "Inherited Properties",
+                "References",
+            ):
                 index = node.parent.children.index(node)
-                next_node = node.parent.children[index+1]
+                next_node = node.parent.children[index + 1]
                 nodes_to_remove.append(node)
                 nodes_to_remove.append(next_node)
             elif node.astext().startswith("subclasses ---"):

--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -23,7 +23,13 @@ from ..analyzer.nodes import (
     DataTypeNode,
     make_data_type_node,
 )
-from ..utils import get_first_child, find_children, output_log, LOG_LEVEL_WARN, LOG_LEVEL_DEBUG
+from ..utils import (
+    get_first_child,
+    find_children,
+    output_log,
+    LOG_LEVEL_WARN,
+    LOG_LEVEL_DEBUG,
+)
 
 
 REGEX_MATCH_DATA_TYPE_PAIR = re.compile(r"^\((.*)\) pair$")
@@ -35,29 +41,59 @@ REGEX_MATCH_DATA_TYPE_ENUM_IN_DEFAULT = re.compile(r"^enum in \[(.*)\], default 
 REGEX_MATCH_DATA_TYPE_ENUM_IN = re.compile(r"^enum in \[(.*)\](, \(.+\))*,?$")
 REGEX_MATCH_DATA_TYPE_SET_IN = re.compile(r"^enum set in \{(.*)\}(, \(.+\))*,?$")  # noqa # pylint: disable=C0301
 REGEX_MATCH_DATA_TYPE_BOOLEAN_DEFAULT = re.compile(r"^boolean, default (False|True)$")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_BOOLEAN_ARRAY_OF = re.compile(r"^boolean array of ([0-9]+) items(, .+)*$")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_MATHUTILS_VALUES = re.compile(r"^`((mathutils.)*(Color|Euler|Matrix|Quaternion|Vector))`$")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_NUMBER_ARRAY_OF = re.compile(r"^(int|float) array of ([0-9]+) items in \[([-einf+0-9,. ]+)\](, .+)*$")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_MATHUTILS_ARRAY_OF = re.compile(r"^`(mathutils.[a-zA-Z]+)` (rotation )*of ([0-9]+) items in \[([-einf+0-9,. ]+)\](, .+)*$")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_NUMBER_IN = re.compile(r"^(int|float) in \[([-einf+0-9,. ]+)\](, .+)*$")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_FLOAT_MULTI_DIMENSIONAL_ARRAY_OF = re.compile(r"^float multi-dimensional array of ([0-9]) \* ([0-9]) items in \[([-einf+0-9,. ]+)\](, .+)*$")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_MATHUTILS_MATRIX_OF = re.compile(r"^`mathutils.Matrix` of ([0-9]) \* ([0-9]) items in \[([-einf+0-9,. ]+)\](, .+)*$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_BOOLEAN_ARRAY_OF = re.compile(
+    r"^boolean array of ([0-9]+) items(, .+)*$"
+)  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_MATHUTILS_VALUES = re.compile(
+    r"^`((mathutils.)*(Color|Euler|Matrix|Quaternion|Vector))`$"
+)  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_NUMBER_ARRAY_OF = re.compile(
+    r"^(int|float) array of ([0-9]+) items in \[([-einf+0-9,. ]+)\](, .+)*$"
+)  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_MATHUTILS_ARRAY_OF = re.compile(
+    r"^`(mathutils.[a-zA-Z]+)` (rotation )*of ([0-9]+) items in \[([-einf+0-9,. ]+)\](, .+)*$"
+)  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_NUMBER_IN = re.compile(
+    r"^(int|float) in \[([-einf+0-9,. ]+)\](, .+)*$"
+)  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_FLOAT_MULTI_DIMENSIONAL_ARRAY_OF = re.compile(
+    r"^float multi-dimensional array of ([0-9]) \* ([0-9]) items in \[([-einf+0-9,. ]+)\](, .+)*$"
+)  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_MATHUTILS_MATRIX_OF = re.compile(
+    r"^`mathutils.Matrix` of ([0-9]) \* ([0-9]) items in \[([-einf+0-9,. ]+)\](, .+)*$"
+)  # noqa # pylint: disable=C0301
 REGEX_MATCH_DATA_TYPE_STRING = re.compile(r"^(str|strings|string)\.*$")
 REGEX_MATCH_DATA_TYPE_INTEGER = re.compile(r"^(int|integer|)\.*$")
-REGEX_MATCH_DATA_TYPE_VALUE_BPY_PROP_COLLECTION_OF = re.compile(r"^`([a-zA-Z0-9]+)` `bpy_prop_collection` of `([a-zA-Z0-9]+)`,$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_VALUE_BPY_PROP_COLLECTION_OF = re.compile(
+    r"^`([a-zA-Z0-9]+)` `bpy_prop_collection` of `([a-zA-Z0-9]+)`,$"
+)  # noqa # pylint: disable=C0301
 REGEX_MATCH_DATA_TYPE_SEQUENCE_OF = re.compile(r"^sequence of `([a-zA-Z0-9_.]+)`$")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_BPY_PROP_COLLECTION_OF = re.compile(r"^`bpy_prop_collection` of `([a-zA-Z0-9]+)`")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_LIST_OF_VALUE_OBJECTS = re.compile(r"^List of `([A-Za-z0-9]+)` objects$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_BPY_PROP_COLLECTION_OF = re.compile(
+    r"^`bpy_prop_collection` of `([a-zA-Z0-9]+)`"
+)  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_LIST_OF_VALUE_OBJECTS = re.compile(
+    r"^List of `([A-Za-z0-9]+)` objects$"
+)  # noqa # pylint: disable=C0301
 REGEX_MATCH_DATA_TYPE_LIST_OF_VALUE = re.compile(r"^[Ll]ist of `([A-Za-z0-9_.]+)`$")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_LIST_OF_NUMBER_OR_STRING = re.compile(r"^(list|sequence) of (float|int|str)")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_LIST_OF_PARENTHESES_VALUE = re.compile(r"^list of \(([a-zA-Z.,` ]+)\)")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_BMELEMSEQ_OF_VALUE = re.compile(r"`BMElemSeq` of `([a-zA-Z0-9]+)`$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_LIST_OF_NUMBER_OR_STRING = re.compile(
+    r"^(list|sequence) of (float|int|str)"
+)  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_LIST_OF_PARENTHESES_VALUE = re.compile(
+    r"^list of \(([a-zA-Z.,` ]+)\)"
+)  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_BMELEMSEQ_OF_VALUE = re.compile(
+    r"`BMElemSeq` of `([a-zA-Z0-9]+)`$"
+)  # noqa # pylint: disable=C0301
 REGEX_MATCH_DATA_TYPE_TUPLE_OF_VALUE = re.compile(r"^tuple of `([a-zA-Z0-9.]+)`('s)*$")  # noqa # pylint: disable=C0301
-REGEX_MATCH_DATA_TYPE_LIST_OR_DICT_OR_SET_OR_TUPLE = re.compile(r"^`*(list|dict|set|tuple)`*\.*$")  # noqa # pylint: disable=C0301
+REGEX_MATCH_DATA_TYPE_LIST_OR_DICT_OR_SET_OR_TUPLE = re.compile(
+    r"^`*(list|dict|set|tuple)`*\.*$"
+)  # noqa # pylint: disable=C0301
 REGEX_MATCH_DATA_TYPE_OT = re.compile(r"^`([A-Z]+)_OT_([A-Za-z_]+)`,$")
 REGEX_MATCH_DATA_TYPE_DOT = re.compile(r"^`([a-zA-Z0-9_]+\.[a-zA-Z0-9_.]+)`$")
 REGEX_MATCH_DATA_TYPE_DOT_COMMA = re.compile(r"^`([a-zA-Z0-9_.]+)`(,)*$")
-REGEX_MATCH_DATA_TYPE_START_AND_END_WITH_PARENTHESES = re.compile(r"^\(([a-zA-Z0-9_.,` ]+)\)$")
+REGEX_MATCH_DATA_TYPE_START_AND_END_WITH_PARENTHESES = re.compile(
+    r"^\(([a-zA-Z0-9_.,` ]+)\)$"
+)
 REGEX_MATCH_DATA_TYPE_NAME = re.compile(r"^[a-zA-Z0-9_.]+$")
 # pylint: enable=line-too-long
 
@@ -76,7 +112,6 @@ class EntryPoint:
 
 
 class DataTypeRefiner(TransformerBase):
-
     def __init__(self, documents: List[nodes.document], **kwargs):
         super().__init__(documents, **kwargs)
         self._entry_points = None
@@ -85,7 +120,9 @@ class DataTypeRefiner(TransformerBase):
 
         self._entry_points_cache: Dict[str, Set] = {}
 
-    def _build_entry_points(self, documents: List[nodes.document]) -> List['EntryPoint']:
+    def _build_entry_points(
+        self, documents: List[nodes.document]
+    ) -> List['EntryPoint']:
         entry_points: List['EntryPoint'] = []
 
         for document in documents:
@@ -116,8 +153,12 @@ class DataTypeRefiner(TransformerBase):
         return entry_points
 
     def _parse_custom_data_type(
-            self, string_to_parse: str, uniq_full_names: Set[str],
-            uniq_module_names: Set[str], module_name: str) -> str:
+        self,
+        string_to_parse: str,
+        uniq_full_names: Set[str],
+        uniq_module_names: Set[str],
+        module_name: str,
+    ) -> str:
         dtype_str = string_to_parse
         if dtype_str in uniq_full_names:
             return dtype_str
@@ -134,27 +175,36 @@ class DataTypeRefiner(TransformerBase):
 
     # pylint: disable=R0913
     def _get_refined_data_type_fast(
-            self, dtype_str: str, uniq_full_names: Set[str],
-            uniq_module_names: Set[str], module_name: str,
-            variable_kind: str,
-            additional_info: Dict[str, typing.Any] = None) -> List['DataTypeNode']:
+        self,
+        dtype_str: str,
+        uniq_full_names: Set[str],
+        uniq_module_names: Set[str],
+        module_name: str,
+        variable_kind: str,
+        additional_info: Dict[str, typing.Any] = None,
+    ) -> List['DataTypeNode']:
         # pylint: disable=R0912,R0911,R0915
         if REGEX_MATCH_DATA_TYPE_SPACE.match(dtype_str):
             return [make_data_type_node("typing.Any")]
 
         if m := re.match(r"list of callable\[`([0-9a-zA-Z.]+)`\]", dtype_str):
             s = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names,
-                module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [
-                    make_data_type_node("list[collections.abc.Callable[[`bpy.types.Scene`, None]]]")
+                    make_data_type_node(
+                        "list[collections.abc.Callable[[`bpy.types.Scene`, None]]]"
+                    )
                 ]
 
         if dtype_str == "Same type with self class":
             s = self._parse_custom_data_type(
-                additional_info["self_class"], uniq_full_names,
-                uniq_module_names, module_name)
+                additional_info["self_class"],
+                uniq_full_names,
+                uniq_module_names,
+                module_name,
+            )
             if s:
                 return [make_data_type_node(f"`{s}`")]
 
@@ -178,12 +228,14 @@ class DataTypeRefiner(TransformerBase):
         # "[23][dD] [Vv]ector"
         if dtype_str[1:].lower() == "d vector":
             s = self._parse_custom_data_type(
-                "Vector", uniq_full_names, uniq_module_names, module_name)
+                "Vector", uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"`{s}`")]
         if dtype_str in ("4x4 `mathutils.Matrix`", "4x4 `Matrix`"):
             s = self._parse_custom_data_type(
-                "Matrix", uniq_full_names, uniq_module_names, module_name)
+                "Matrix", uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"`{s}`")]
 
@@ -228,41 +280,47 @@ class DataTypeRefiner(TransformerBase):
         if m := REGEX_MATCH_DATA_TYPE_MATHUTILS_VALUES.match(dtype_str):
             if variable_kind in ('FUNC_ARG', 'CONST', 'CLS_ATTR'):
                 s = self._parse_custom_data_type(
-                    m.group(1), uniq_full_names, uniq_module_names,
-                    module_name)
+                    m.group(1), uniq_full_names, uniq_module_names, module_name
+                )
                 if s:
-                    return [make_data_type_node("collections.abc.Sequence[float]"),
-                            make_data_type_node(f"`{s}`")]
+                    return [
+                        make_data_type_node("collections.abc.Sequence[float]"),
+                        make_data_type_node(f"`{s}`"),
+                    ]
 
         # Ex: int array of 2 items in [-32768, 32767], default (0, 0)
         if m := REGEX_MATCH_DATA_TYPE_NUMBER_ARRAY_OF.match(dtype_str):
             if m.group(1) in ("int", "float"):
                 if variable_kind == 'FUNC_ARG':
-                    return [make_data_type_node(f"collections.abc.Iterable[{m.group(1)}]")]
-                return [make_data_type_node(f"`bpy.types.bpy_prop_array`[{m.group(1)}]")]
+                    return [
+                        make_data_type_node(f"collections.abc.Iterable[{m.group(1)}]")
+                    ]
+                return [
+                    make_data_type_node(f"`bpy.types.bpy_prop_array`[{m.group(1)}]")
+                ]
         # Ex: :`mathutils.Euler` rotation of 3 items in [-inf, inf],
         #     default (0.0, 0.0, 0.0)
         if m := REGEX_MATCH_DATA_TYPE_MATHUTILS_ARRAY_OF.match(dtype_str):
             s = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names,
-                module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 tuple_elms = ["float"] * int(m.group(3))
                 return [
                     make_data_type_node("list[float]"),
                     make_data_type_node(f"tuple[{', '.join(tuple_elms)}]"),
-                    make_data_type_node(f"`{s}`")
+                    make_data_type_node(f"`{s}`"),
                 ]
 
         # Ex: float triplet
         if dtype_str == "float triplet":
             s = self._parse_custom_data_type(
-                "mathutils.Vector", uniq_full_names, uniq_module_names,
-                module_name)
+                "mathutils.Vector", uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [
                     make_data_type_node("collections.abc.Sequence[float]"),
-                    make_data_type_node(f"`{s}`")
+                    make_data_type_node(f"`{s}`"),
                 ]
         # Ex: int in [-inf, inf], default 0, (readonly)
         if m := REGEX_MATCH_DATA_TYPE_NUMBER_IN.match(dtype_str):
@@ -276,18 +334,18 @@ class DataTypeRefiner(TransformerBase):
 
         # Ex: float multi-dimensional array of 3 * 3 items in [-inf, inf]
         if m := REGEX_MATCH_DATA_TYPE_FLOAT_MULTI_DIMENSIONAL_ARRAY_OF.match(dtype_str):  # noqa # pylint: disable=C0301
-            tuple_elems = [
-                f"tuple[{', '.join(['float'] * int(m.group(1)))}]"
-            ] * int(m.group(2))
+            tuple_elems = [f"tuple[{', '.join(['float'] * int(m.group(1)))}]"] * int(
+                m.group(2)
+            )
             return [
                 make_data_type_node("list[list[float]]"),
-                make_data_type_node(f"tuple[{', '.join(tuple_elems)}]")
+                make_data_type_node(f"tuple[{', '.join(tuple_elems)}]"),
             ]
 
         if m := REGEX_MATCH_DATA_TYPE_MATHUTILS_MATRIX_OF.match(dtype_str):
             s = self._parse_custom_data_type(
-                "mathutils.Matrix", uniq_full_names, uniq_module_names,
-                module_name)
+                "mathutils.Matrix", uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 tuple_elems = [
                     f"tuple[{', '.join(['float'] * int(m.group(1)))}]"
@@ -295,7 +353,7 @@ class DataTypeRefiner(TransformerBase):
                 return [
                     make_data_type_node("list[list[float]]"),
                     make_data_type_node(f"tuple[{', '.join(tuple_elems)}]"),
-                    make_data_type_node(f"`{s}`")
+                    make_data_type_node(f"`{s}`"),
                 ]
 
         if dtype_str == "double":
@@ -314,15 +372,18 @@ class DataTypeRefiner(TransformerBase):
 
         if dtype_str.startswith("`bgl.Buffer` "):
             s1 = self._parse_custom_data_type(
-                "bgl.Buffer", uniq_full_names, uniq_module_names, module_name)
+                "bgl.Buffer", uniq_full_names, uniq_module_names, module_name
+            )
             if s1:
                 return [make_data_type_node(f"`{s1}`")]
 
         if m := REGEX_MATCH_DATA_TYPE_VALUE_BPY_PROP_COLLECTION_OF.match(dtype_str):  # noqa # pylint: disable=C0301
             s1 = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names, module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             s2 = self._parse_custom_data_type(
-                m.group(2), uniq_full_names, uniq_module_names, module_name)
+                m.group(2), uniq_full_names, uniq_module_names, module_name
+            )
             if s1 and s2:
                 return [make_data_type_node(f"`{s1}`")]
 
@@ -336,32 +397,38 @@ class DataTypeRefiner(TransformerBase):
         #   Pattern: sequence of string tuples or a function
         if dtype_str == "sequence of string tuples or a function":
             return [
-                make_data_type_node("collections.abc.Iterable[collections.abc.Iterable[str]]"),
-                make_data_type_node("collections.abc.Callable")
+                make_data_type_node(
+                    "collections.abc.Iterable[collections.abc.Iterable[str]]"
+                ),
+                make_data_type_node("collections.abc.Callable"),
             ]
         # Ex: sequence of bpy.types.Action
         if m := REGEX_MATCH_DATA_TYPE_SEQUENCE_OF.match(dtype_str):
             s = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names, module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"collections.abc.Iterable[`{s}`]")]
         # Ex: `bpy_prop_collection` of `ThemeStripColor`,
         #     (readonly, never None)
         if m := REGEX_MATCH_DATA_TYPE_BPY_PROP_COLLECTION_OF.match(dtype_str):
             s = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names, module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"`bpy.types.bpy_prop_collection`[`{s}`]")]
         # Ex: List of FEdge objects
         if m := REGEX_MATCH_DATA_TYPE_LIST_OF_VALUE_OBJECTS.match(dtype_str):
             s = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names, module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"list[`{s}`]")]
         # Ex: list of FEdge
         if m := REGEX_MATCH_DATA_TYPE_LIST_OF_VALUE.match(dtype_str):
             s = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names, module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"list[`{s}`]")]
         # Ex: list of ints
@@ -375,24 +442,26 @@ class DataTypeRefiner(TransformerBase):
                 im = re.match(r"^`([a-zA-Z.]+)`$", item.strip())
                 if im:
                     s = self._parse_custom_data_type(
-                        im.group(1), uniq_full_names, uniq_module_names,
-                        module_name)
+                        im.group(1), uniq_full_names, uniq_module_names, module_name
+                    )
                     if s:
                         dtypes.append(make_data_type_node(f"list[`{s}`]"))
             return dtypes
         # Ex: BMElemSeq of BMEdge
         if m := REGEX_MATCH_DATA_TYPE_BMELEMSEQ_OF_VALUE.match(dtype_str):
             s = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names, module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [
                     make_data_type_node(f"list[`{s}`]"),
-                    make_data_type_node("`bmesh.types.BMElemSeq`")
+                    make_data_type_node("`bmesh.types.BMElemSeq`"),
                 ]
         # Ex: tuple of mathutils.Vector's
         if m := REGEX_MATCH_DATA_TYPE_TUPLE_OF_VALUE.match(dtype_str):
             s = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names, module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"tuple[`{s}`, ...]")]
 
@@ -404,7 +473,8 @@ class DataTypeRefiner(TransformerBase):
                 sp = sp.strip()
                 if m2 := REGEX_MATCH_DATA_TYPE_DOT_COMMA.match(sp):
                     s = self._parse_custom_data_type(
-                        m2.group(1), uniq_full_names, uniq_module_names, module_name)
+                        m2.group(1), uniq_full_names, uniq_module_names, module_name
+                    )
                     if s:
                         dtypes.append(f"`{s}`")
             if len(dtypes) != 0:
@@ -421,14 +491,15 @@ class DataTypeRefiner(TransformerBase):
         # Ex: bpy.types.Struct subclass
         if dtype_str == "`bpy.types.Struct` subclass":
             s = self._parse_custom_data_type(
-                "bpy.types.Struct", uniq_full_names, uniq_module_names,
-                module_name)
+                "bpy.types.Struct", uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"`{s}`")]
 
         if dtype_str == "`bpy_struct`":
             s = self._parse_custom_data_type(
-                "bpy_struct", uniq_full_names, uniq_module_names, module_name)
+                "bpy_struct", uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"`{s}`")]
 
@@ -436,33 +507,41 @@ class DataTypeRefiner(TransformerBase):
         if m := REGEX_MATCH_DATA_TYPE_OT.match(dtype_str):
             idname = f"bpy.ops.{m.group(1).lower()}.{m.group(2)}"
             s = self._parse_custom_data_type(
-                idname, uniq_full_names, uniq_module_names, module_name)
+                idname, uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"`{s}`")]
 
         if m := REGEX_MATCH_DATA_TYPE_DOT.match(dtype_str):
             s = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names, module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"`{s}`")]
 
         if m := REGEX_MATCH_DATA_TYPE_DOT_COMMA.match(dtype_str):
             s = self._parse_custom_data_type(
-                m.group(1), uniq_full_names, uniq_module_names, module_name)
+                m.group(1), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"`{s}`")]
 
         if m := REGEX_MATCH_DATA_TYPE_NAME.match(dtype_str):
             s = self._parse_custom_data_type(
-                m.group(0), uniq_full_names, uniq_module_names, module_name)
+                m.group(0), uniq_full_names, uniq_module_names, module_name
+            )
             if s:
                 return [make_data_type_node(f"`{s}`")]
 
         return None
 
     def _get_data_type_options(
-            self, dtype_str: str, module_name: str, variable_kind: str,
-            additional_info: Dict[str, typing.Any] = None) -> Tuple[List[str], str]:
+        self,
+        dtype_str: str,
+        module_name: str,
+        variable_kind: str,
+        additional_info: Dict[str, typing.Any] = None,
+    ) -> Tuple[List[str], str]:
         if module_name.startswith("bpy."):
             if m := _REGEX_DATA_TYPE_OPTION_STR.search(dtype_str):
                 option_str = m.group(1)
@@ -471,8 +550,10 @@ class DataTypeRefiner(TransformerBase):
                 for opt in options:
                     if opt not in ("optional", "readonly", "never none"):
                         has_unknown_option = True
-                        output_log(LOG_LEVEL_WARN,
-                                   f"Unknown option '{opt}' is found from {dtype_str}")
+                        output_log(
+                            LOG_LEVEL_WARN,
+                            f"Unknown option '{opt}' is found from {dtype_str}",
+                        )
 
                 # If there is unknown parameter options, we don't strip them from
                 # original string.
@@ -481,7 +562,9 @@ class DataTypeRefiner(TransformerBase):
 
                 # Strip the unused string to speed up the later parsing process.
                 stripped = _REGEX_DATA_TYPE_OPTION_STR.sub("", dtype_str)
-                output_log(LOG_LEVEL_DEBUG, f"Data type is stripped: {dtype_str} -> {stripped}")
+                output_log(
+                    LOG_LEVEL_DEBUG, f"Data type is stripped: {dtype_str} -> {stripped}"
+                )
 
                 return options, stripped
 
@@ -494,24 +577,36 @@ class DataTypeRefiner(TransformerBase):
         # From this, we assumed non-bpy module.
         if m := _REGEX_DATA_TYPE_OPTION_END_WITH_NONE.search(dtype_str):
             stripped = _REGEX_DATA_TYPE_OPTION_END_WITH_NONE.sub("", dtype_str)
-            output_log(LOG_LEVEL_DEBUG, f"Data type is stripped: {dtype_str} -> {stripped}")
+            output_log(
+                LOG_LEVEL_DEBUG, f"Data type is stripped: {dtype_str} -> {stripped}"
+            )
 
             return [""], stripped
 
         return ["never none"], dtype_str
 
     def _get_refined_data_type(
-            self, dtype_str: str, module_name: str, variable_kind: str,
-            additional_info: Dict[str, typing.Any] = None) -> List[DataTypeNode]:
-
+        self,
+        dtype_str: str,
+        module_name: str,
+        variable_kind: str,
+        additional_info: Dict[str, typing.Any] = None,
+    ) -> List[DataTypeNode]:
         assert variable_kind in (
-            'FUNC_ARG', 'FUNC_RET', 'CONST', 'CLS_ATTR', 'CLS_BASE')
+            'FUNC_ARG',
+            'FUNC_RET',
+            'CONST',
+            'CLS_ATTR',
+            'CLS_BASE',
+        )
 
         options, dtype_str_changed = self._get_data_type_options(
-            dtype_str, module_name, variable_kind, additional_info)
+            dtype_str, module_name, variable_kind, additional_info
+        )
 
         result = self._get_refined_data_type_internal(
-            dtype_str_changed, module_name, variable_kind, additional_info)
+            dtype_str_changed, module_name, variable_kind, additional_info
+        )
 
         # Add options.
         for r in result:
@@ -522,14 +617,18 @@ class DataTypeRefiner(TransformerBase):
         output_log(
             LOG_LEVEL_DEBUG,
             f"Result of refining (kind={variable_kind}): "
-            f"{dtype_str} -> {', '.join(r.to_string() for r in result)}")
+            f"{dtype_str} -> {', '.join(r.to_string() for r in result)}",
+        )
 
         return result
 
     def _get_refined_data_type_internal(
-            self, dtype_str: str, module_name: str, variable_kind: str,
-            additional_info: Dict[str, typing.Any] = None) -> List[DataTypeNode]:
-
+        self,
+        dtype_str: str,
+        module_name: str,
+        variable_kind: str,
+        additional_info: Dict[str, typing.Any] = None,
+    ) -> List[DataTypeNode]:
         dtype_str = dtype_str.strip()
 
         uniq_full_names = self._entry_points_cache["uniq_full_names"]
@@ -545,17 +644,30 @@ class DataTypeRefiner(TransformerBase):
             dtypes: List[DataTypeNode] = []
             for s in sp:
                 d = self._get_refined_data_type_fast(
-                    s.strip(), uniq_full_names, uniq_module_names,
-                    module_name, variable_kind, additional_info)
+                    s.strip(),
+                    uniq_full_names,
+                    uniq_module_names,
+                    module_name,
+                    variable_kind,
+                    additional_info,
+                )
                 if d is not None:
                     dtypes.extend(d)
             if len(dtypes) >= 1:
-                return [make_data_type_node(
-                    f"tuple[{', '.join([d.astext() for d in dtypes])}]")]
+                return [
+                    make_data_type_node(
+                        f"tuple[{', '.join([d.astext() for d in dtypes])}]"
+                    )
+                ]
 
         result = self._get_refined_data_type_fast(
-            dtype_str, uniq_full_names, uniq_module_names, module_name,
-            variable_kind, additional_info)
+            dtype_str,
+            uniq_full_names,
+            uniq_module_names,
+            module_name,
+            variable_kind,
+            additional_info,
+        )
         if result is not None:
             return result
 
@@ -571,38 +683,56 @@ class DataTypeRefiner(TransformerBase):
             for s in splist:
                 s = s.strip()
                 result = self._get_refined_data_type_fast(
-                    s, uniq_full_names, uniq_module_names, module_name,
-                    variable_kind, additional_info)
+                    s,
+                    uniq_full_names,
+                    uniq_module_names,
+                    module_name,
+                    variable_kind,
+                    additional_info,
+                )
                 if result is not None:
                     dtypes.extend(result)
             return dtypes
         return []
 
     def _parse_from_description(
-            self, module_name: str, description_str: str = None,
-            additional_info: Dict[str, typing.Any] = None) -> List[DataTypeNode]:
-
+        self,
+        module_name: str,
+        description_str: str = None,
+        additional_info: Dict[str, typing.Any] = None,
+    ) -> List[DataTypeNode]:
         uniq_full_names = self._entry_points_cache["uniq_full_names"]
         uniq_module_names = self._entry_points_cache["uniq_module_names"]
 
         if description_str == "An instance of this object.":
             s = self._parse_custom_data_type(
-                additional_info["self_class"], uniq_full_names,
-                uniq_module_names, module_name)
+                additional_info["self_class"],
+                uniq_full_names,
+                uniq_module_names,
+                module_name,
+            )
             return [make_data_type_node(f"`{s}`")]
 
         return []
 
     def _refine(self, document: nodes.document):
-        def refine(dtype_list_node: DataTypeListNode, module_name: str,
-                   variable_kind: str, description_str: str = None,
-                   additional_info: Dict[str, typing.Any] = None):
+        def refine(
+            dtype_list_node: DataTypeListNode,
+            module_name: str,
+            variable_kind: str,
+            description_str: str = None,
+            additional_info: Dict[str, typing.Any] = None,
+        ):
             dtype_nodes = find_children(dtype_list_node, DataTypeNode)
             new_dtype_nodes = []
 
-            new_dtype_nodes.extend(self._parse_from_description(
-                module_name, description_str=description_str,
-                additional_info=additional_info))
+            new_dtype_nodes.extend(
+                self._parse_from_description(
+                    module_name,
+                    description_str=description_str,
+                    additional_info=additional_info,
+                )
+            )
 
             for dtype_node in dtype_nodes:
                 mod_options = []
@@ -615,9 +745,14 @@ class DataTypeRefiner(TransformerBase):
                     skip_refine = "skip-refine" in mod_options
                 if skip_refine:
                     continue
-                new_dtype_nodes.extend(self._get_refined_data_type(
-                    dtype_node.astext(), module_name, variable_kind,
-                    additional_info=additional_info))
+                new_dtype_nodes.extend(
+                    self._get_refined_data_type(
+                        dtype_node.astext(),
+                        module_name,
+                        variable_kind,
+                        additional_info=additional_info,
+                    )
+                )
                 dtype_list_node.remove(dtype_node)
 
             for node in new_dtype_nodes:
@@ -639,26 +774,38 @@ class DataTypeRefiner(TransformerBase):
                 arg_nodes = find_children(arg_list_node, ArgumentNode)
                 for arg_node in arg_nodes:
                     dtype_list_node = arg_node.element(DataTypeListNode)
-                    refine(dtype_list_node, module_name, 'FUNC_ARG',
-                           additional_info={"self_class": f"{module_name}.{class_name}"})
+                    refine(
+                        dtype_list_node,
+                        module_name,
+                        'FUNC_ARG',
+                        additional_info={"self_class": f"{module_name}.{class_name}"},
+                    )
 
                 return_node = func_node.element(FunctionReturnNode)
                 description = return_node.element(DescriptionNode).astext()
                 dtype_list_node = return_node.element(DataTypeListNode)
-                refine(dtype_list_node, module_name, 'FUNC_RET',
-                       description_str=description,
-                       additional_info={"self_class": f"{module_name}.{class_name}"})
+                refine(
+                    dtype_list_node,
+                    module_name,
+                    'FUNC_RET',
+                    description_str=description,
+                    additional_info={"self_class": f"{module_name}.{class_name}"},
+                )
 
             attr_list_node = class_node.element(AttributeListNode)
             attr_nodes = find_children(attr_list_node, AttributeNode)
             for attr_node in attr_nodes:
                 attr_name = attr_node.element(NameNode).astext()
                 dtype_list_node = attr_node.element(DataTypeListNode)
-                refine(dtype_list_node, module_name, 'CONST',
-                       additional_info={
-                           "self_class": f"{module_name}.{class_name}",
-                           "data_name": f"{attr_name}"
-                       })
+                refine(
+                    dtype_list_node,
+                    module_name,
+                    'CONST',
+                    additional_info={
+                        "self_class": f"{module_name}.{class_name}",
+                        "data_name": f"{attr_name}",
+                    },
+                )
 
             base_class_list_node = class_node.element(BaseClassListNode)
             base_class_nodes = find_children(base_class_list_node, BaseClassNode)
@@ -673,8 +820,9 @@ class DataTypeRefiner(TransformerBase):
             for arg_node in arg_nodes:
                 arg_name = arg_node.element(NameNode).astext()
                 dtype_list_node = arg_node.element(DataTypeListNode)
-                refine(dtype_list_node, module_name, 'FUNC_ARG',
-                       description_str=arg_name)
+                refine(
+                    dtype_list_node, module_name, 'FUNC_ARG', description_str=arg_name
+                )
 
             return_node = func_node.element(FunctionReturnNode)
             dtype_list_node = return_node.element(DataTypeListNode)
@@ -684,8 +832,12 @@ class DataTypeRefiner(TransformerBase):
         for data_node in data_nodes:
             data_name = data_node.element(NameNode).astext()
             dtype_list_node = data_node.element(DataTypeListNode)
-            refine(dtype_list_node, module_name, 'CONST',
-                   additional_info={"data_name": f"{data_name}"})
+            refine(
+                dtype_list_node,
+                module_name,
+                'CONST',
+                additional_info={"data_name": f"{data_name}"},
+            )
 
     @classmethod
     def name(cls) -> str:
@@ -696,9 +848,11 @@ class DataTypeRefiner(TransformerBase):
             self._entry_points = self._build_entry_points(self.documents)
 
         self._entry_points_cache["uniq_full_names"] = {
-            e.fullname() for e in self._entry_points}
+            e.fullname() for e in self._entry_points
+        }
         self._entry_points_cache["uniq_module_names"] = {
-            e.module for e in self._entry_points}
+            e.module for e in self._entry_points
+        }
 
         for document in self.documents:
             self._refine(document)

--- a/src/fake_bpy_module/transformer/default_value_filler.py
+++ b/src/fake_bpy_module/transformer/default_value_filler.py
@@ -13,7 +13,6 @@ from ..utils import find_children
 
 
 class DefaultValueFiller(TransformerBase):
-
     def _fill(self, document: nodes.document):
         func_nodes = document.findall(FunctionNode)
         for func_node in func_nodes:
@@ -51,7 +50,9 @@ class DefaultValueFiller(TransformerBase):
                         "tuple": "()",
                     }
                     if dtype in BUILTIN_DTYPE_DEFAULT_VALUE_MAP:
-                        default_value_node.add_text(BUILTIN_DTYPE_DEFAULT_VALUE_MAP[dtype])
+                        default_value_node.add_text(
+                            BUILTIN_DTYPE_DEFAULT_VALUE_MAP[dtype]
+                        )
                         continue
 
                     # Modifier data type.
@@ -67,7 +68,10 @@ class DefaultValueFiller(TransformerBase):
                         "collections.abc.Sequence": "[]",
                     }
                     found_type = False
-                    for mod_dtype, default_value in MODIFIER_DTYPE_DEFAULT_VALUE_MAP.items():
+                    for (
+                        mod_dtype,
+                        default_value,
+                    ) in MODIFIER_DTYPE_DEFAULT_VALUE_MAP.items():
                         if dtype.startswith(mod_dtype):
                             default_value_node.add_text(default_value)
                             found_type = True

--- a/src/fake_bpy_module/transformer/dependency_builder.py
+++ b/src/fake_bpy_module/transformer/dependency_builder.py
@@ -15,7 +15,12 @@ from ..analyzer.roles import (
     ClassRef,
 )
 from ..utils import get_first_child, find_children, append_child
-from .utils import ModuleStructure, get_module_name, get_base_name, build_module_structure
+from .utils import (
+    ModuleStructure,
+    get_module_name,
+    get_base_name,
+    build_module_structure,
+)
 
 
 class Dependency:
@@ -36,8 +41,7 @@ class Dependency:
     @property
     def type_lists(self) -> List[str]:
         if not self._type_lists:
-            raise RuntimeError(
-                "At least 1 element must be added to type lists")
+            raise RuntimeError("At least 1 element must be added to type lists")
         return self._type_lists
 
     def add_type(self, type_: str):
@@ -45,15 +49,15 @@ class Dependency:
 
 
 class DependencyBuilder(TransformerBase):
-
     def __init__(self, documents: List[nodes.document], **kwargs):
         super().__init__(documents, **kwargs)
         self._package_structure: ModuleStructure = None
         if "package_structure" in kwargs:
             self._package_structure = kwargs["package_structure"]
 
-    def _get_import_module_path(self, module_structure: ModuleStructure,
-                                data_type_1: str, data_type_2: str):
+    def _get_import_module_path(
+        self, module_structure: ModuleStructure, data_type_1: str, data_type_2: str
+    ):
         mod_names_full_1 = get_module_name(data_type_1, module_structure)
         mod_names_full_2 = get_module_name(data_type_2, module_structure)
         if mod_names_full_1 is None or mod_names_full_2 is None:
@@ -114,10 +118,13 @@ class DependencyBuilder(TransformerBase):
 
         return module_path
 
-    def _add_dependency(self, dependencies: List[Dependency],
-                        module_structure: ModuleStructure,
-                        data_type_1: str, data_type_2: str):
-
+    def _add_dependency(
+        self,
+        dependencies: List[Dependency],
+        module_structure: ModuleStructure,
+        data_type_1: str,
+        data_type_2: str,
+    ):
         mod = self._get_import_module_path(module_structure, data_type_1, data_type_2)
         base = get_base_name(data_type_1)
         if mod is None:
@@ -138,8 +145,8 @@ class DependencyBuilder(TransformerBase):
                 target_dep.add_type(base)
 
     def _build_dependencies(
-            self, document: nodes.document, package_structure: ModuleStructure):
-
+        self, document: nodes.document, package_structure: ModuleStructure
+    ):
         dependencies: List[Dependency] = []
         module_node = get_first_child(document, ModuleNode)
         if module_node is None:
@@ -152,8 +159,11 @@ class DependencyBuilder(TransformerBase):
             class_refs = class_node.traverse(ClassRef)
             for class_ref in class_refs:
                 self._add_dependency(
-                    dependencies, package_structure, class_ref.to_string(),
-                    f"{module_name}.{class_name}")
+                    dependencies,
+                    package_structure,
+                    class_ref.to_string(),
+                    f"{module_name}.{class_name}",
+                )
 
         func_nodes = find_children(document, FunctionNode)
         for func_node in func_nodes:
@@ -161,8 +171,11 @@ class DependencyBuilder(TransformerBase):
             class_refs = func_node.traverse(ClassRef)
             for class_ref in class_refs:
                 self._add_dependency(
-                    dependencies, package_structure, class_ref.to_string(),
-                    f"{module_name}.{func_name}")
+                    dependencies,
+                    package_structure,
+                    class_ref.to_string(),
+                    f"{module_name}.{func_name}",
+                )
 
         data_nodes = find_children(document, DataNode)
         for data_node in data_nodes:
@@ -170,8 +183,11 @@ class DependencyBuilder(TransformerBase):
             class_refs = data_node.traverse(ClassRef)
             for class_ref in class_refs:
                 self._add_dependency(
-                    dependencies, package_structure, class_ref.to_string(),
-                    f"{module_name}.{data_name}")
+                    dependencies,
+                    package_structure,
+                    class_ref.to_string(),
+                    f"{module_name}.{data_name}",
+                )
 
         dep_list_node = DependencyListNode()
         for dep in dependencies:

--- a/src/fake_bpy_module/transformer/format_validator.py
+++ b/src/fake_bpy_module/transformer/format_validator.py
@@ -31,7 +31,6 @@ from ..analyzer.roles import (
 
 
 class FormatValidator(TransformerBase):
-
     def _check_num_children(self, node: nodes.Node, expect: int):
         assert len(node.children) == expect, f"{node.pformat()}"
 
@@ -86,12 +85,23 @@ class FormatValidator(TransformerBase):
 
     def _check_data_type_node(self, data_type_node: DataTypeNode):
         for child in data_type_node.children:
-            assert isinstance(child, (nodes.Text, ModuleRef, ClassRef, RefRef,
-                                      nodes.literal, nodes.emphasis,
-                                      nodes.title_reference)), f"{child.pformat()}"
+            assert isinstance(
+                child,
+                (
+                    nodes.Text,
+                    ModuleRef,
+                    ClassRef,
+                    RefRef,
+                    nodes.literal,
+                    nodes.emphasis,
+                    nodes.title_reference,
+                ),
+            ), f"{child.pformat()}"
 
-            if isinstance(child, (nodes.Text, nodes.literal, nodes.emphasis,
-                                  nodes.title_reference)):
+            if isinstance(
+                child,
+                (nodes.Text, nodes.literal, nodes.emphasis, nodes.title_reference),
+            ):
                 for c in child.children:
                     self._check_node(c, nodes.Text)
             elif isinstance(child, ModuleRef):
@@ -112,8 +122,7 @@ class FormatValidator(TransformerBase):
         self._check_node(children[0], NameNode)
         self._check_node(children[1], DescriptionNode)
 
-    def _check_attribute_list_node(self,
-                                   attribute_list_node: AttributeListNode):
+    def _check_attribute_list_node(self, attribute_list_node: AttributeListNode):
         for attr_node in attribute_list_node.children:
             self._check_node(attr_node, AttributeNode)
 
@@ -121,8 +130,7 @@ class FormatValidator(TransformerBase):
         for func_node in function_list_node.children:
             self._check_node(func_node, FunctionNode)
 
-    def _check_base_class_list_node(self,
-                                    base_class_list_node: BaseClassListNode):
+    def _check_base_class_list_node(self, base_class_list_node: BaseClassListNode):
         for base_class_node in base_class_list_node.children:
             self._check_node(base_class_node, BaseClassNode)
 
@@ -187,23 +195,26 @@ class FormatValidator(TransformerBase):
 
     def _check_code_document_node(self, code_document_node: CodeDocumentNode):
         for child in code_document_node.children:
-            assert not isinstance(child, (
-                ModuleNode,
-                FunctionListNode,
-                FunctionNode,
-                FunctionReturnNode,
-                ArgumentListNode,
-                ArgumentNode,
-                AttributeListNode,
-                AttributeNode,
-                BaseClassListNode,
-                BaseClassNode,
-                NameNode,
-                DescriptionNode,
-                DataTypeListNode,
-                DataTypeNode,
-                DefaultValueNode
-            )), f"{code_document_node.pformat()}"
+            assert not isinstance(
+                child,
+                (
+                    ModuleNode,
+                    FunctionListNode,
+                    FunctionNode,
+                    FunctionReturnNode,
+                    ArgumentListNode,
+                    ArgumentNode,
+                    AttributeListNode,
+                    AttributeNode,
+                    BaseClassListNode,
+                    BaseClassNode,
+                    NameNode,
+                    DescriptionNode,
+                    DataTypeListNode,
+                    DataTypeNode,
+                    DefaultValueNode,
+                ),
+            ), f"{code_document_node.pformat()}"
 
     def _check_filename_node(self, source_filename_node: SourceFilenameNode):
         for child in source_filename_node.children:
@@ -224,8 +235,10 @@ class FormatValidator(TransformerBase):
             elif isinstance(child, SourceFilenameNode):
                 self._check_filename_node(child)
             else:
-                raise ValueError(f"{type(child)} must not be a child of "
-                                 f"{type(document)}.\n{document.pformat()}")
+                raise ValueError(
+                    f"{type(child)} must not be a child of "
+                    f"{type(document)}.\n{document.pformat()}"
+                )
 
     def _apply(self, document: nodes.document):
         self._check_document(document)

--- a/src/fake_bpy_module/transformer/mod_applier.py
+++ b/src/fake_bpy_module/transformer/mod_applier.py
@@ -27,12 +27,12 @@ from ..utils import get_first_child, append_child, find_children
 
 
 class ModApplier(TransformerBase):
-
     def get_mod_documents(self) -> List[nodes.document]:
         return self.mod_documents
 
-    def _mod_update_data(self, data_nodes: List[DataNode],
-                         mod_data_nodes: List[DataNode]):
+    def _mod_update_data(
+        self, data_nodes: List[DataNode], mod_data_nodes: List[DataNode]
+    ):
         for mod_data_node in mod_data_nodes:
             mod_data_name_node = mod_data_node.element(NameNode)
             for data_node in data_nodes:
@@ -48,8 +48,9 @@ class ModApplier(TransformerBase):
                     break
 
     # pylint: disable=R0914,R1702
-    def _mod_update_function(self, func_nodes: List[FunctionNode],
-                             mod_func_nodes: List[FunctionNode]):
+    def _mod_update_function(
+        self, func_nodes: List[FunctionNode], mod_func_nodes: List[FunctionNode]
+    ):
         for mod_func_node in mod_func_nodes:
             mod_func_name_node = mod_func_node.element(NameNode)
             mod_arg_list_node = mod_func_node.element(ArgumentListNode)
@@ -79,8 +80,9 @@ class ModApplier(TransformerBase):
                 break
 
     # pylint: disable=R0914,R1702
-    def _mod_update_class(self, class_nodes: List[ClassNode],
-                          mod_class_nodes: List[ClassNode]):
+    def _mod_update_class(
+        self, class_nodes: List[ClassNode], mod_class_nodes: List[ClassNode]
+    ):
         for mod_class_node in mod_class_nodes:
             mod_class_name_node = mod_class_node.element(NameNode)
             mod_class_name = mod_class_name_node.astext()
@@ -120,7 +122,9 @@ class ModApplier(TransformerBase):
                             arg_list_node = func_node.element(ArgumentListNode)
                             arg_list_node.clear()
 
-                            mod_arg_nodes = find_children(mod_arg_list_node, ArgumentNode)
+                            mod_arg_nodes = find_children(
+                                mod_arg_list_node, ArgumentNode
+                            )
                             for mod_arg_node in mod_arg_nodes:
                                 arg_list_node.append_child(mod_arg_node)
 
@@ -147,12 +151,15 @@ class ModApplier(TransformerBase):
                 mod_base_class_list_node = mod_class_node.element(BaseClassListNode)
                 if not mod_base_class_list_node.empty():
                     base_class_list_node.clear()
-                    mod_base_class_nodes = find_children(mod_base_class_list_node, BaseClassNode)
+                    mod_base_class_nodes = find_children(
+                        mod_base_class_list_node, BaseClassNode
+                    )
                     for mod_base_class_node in mod_base_class_nodes:
                         base_class_list_node.append_child(mod_base_class_node)
 
-    def _mod_append_function(self, func_nodes: List[FunctionNode],
-                             mod_func_nodes: List[FunctionNode]):
+    def _mod_append_function(
+        self, func_nodes: List[FunctionNode], mod_func_nodes: List[FunctionNode]
+    ):
         for mod_func_node in mod_func_nodes:
             mod_func_name_node = mod_func_node.element(NameNode)
             mod_arg_list_node = mod_func_node.element(ArgumentListNode)
@@ -161,7 +168,6 @@ class ModApplier(TransformerBase):
             for func_node in func_nodes:
                 func_name_node = func_node.element(NameNode)
                 if func_name_node.astext() == mod_func_name_node.astext():
-
                     arg_list_node = func_node.element(ArgumentListNode)
                     for mod_arg_node in mod_arg_nodes:
                         arg_list_node.append_child(mod_arg_node)
@@ -172,7 +178,9 @@ class ModApplier(TransformerBase):
                     break
 
     # pylint: disable=R0914
-    def _mod_append_class(self, class_nodes: List[ClassNode], mod_class_nodes: List[ClassNode]):
+    def _mod_append_class(
+        self, class_nodes: List[ClassNode], mod_class_nodes: List[ClassNode]
+    ):
         for mod_class_node in mod_class_nodes:
             mod_class_name_node = mod_class_node.element(NameNode)
             mod_class_name = mod_class_name_node.astext()
@@ -220,7 +228,9 @@ class ModApplier(TransformerBase):
                 # Append base classes.
                 base_class_list_node = class_node.element(BaseClassListNode)
                 mod_base_class_list_node = mod_class_node.element(BaseClassListNode)
-                mod_base_class_nodes = find_children(mod_base_class_list_node, BaseClassNode)
+                mod_base_class_nodes = find_children(
+                    mod_base_class_list_node, BaseClassNode
+                )
                 for mod_base_class_node in mod_base_class_nodes:
                     base_class_list_node.append_child(mod_base_class_node)
 
@@ -258,7 +268,8 @@ class ModApplier(TransformerBase):
                 "line_length_limit": 20000,
             }
             mod_document: nodes.document = publish_doctree(
-                contents, settings_overrides=settings_overrides)
+                contents, settings_overrides=settings_overrides
+            )
 
             fixture = BaseClassFixture([mod_document])
             fixture.apply()
@@ -281,7 +292,7 @@ class ModApplier(TransformerBase):
                     mod_class_nodes = find_children(mod_document, ClassNode)
                     for mod_class_node in mod_class_nodes:
                         append_child(document, mod_class_node.deepcopy())
-                else:   # If the module is not found, add whole document.
+                else:  # If the module is not found, add whole document.
                     mod_type_nodes = mod_document.findall(ModTypeNode)
                     for mod_type_node in mod_type_nodes:
                         mod_document.remove(mod_type_node)
@@ -307,7 +318,9 @@ class ModApplier(TransformerBase):
                     mod_class_nodes = find_children(mod_document, ClassNode)
                     self._mod_append_class(class_nodes, mod_class_nodes)
                 else:
-                    raise ValueError(f"Modules to be appended are not found {mod_module_name}")
+                    raise ValueError(
+                        f"Modules to be appended are not found {mod_module_name}"
+                    )
             elif mod_type_node.astext() == "update":
                 mod_module_node = get_first_child(mod_document, ModuleNode)
                 mod_module_name_node = mod_module_node.element(NameNode)
@@ -332,6 +345,10 @@ class ModApplier(TransformerBase):
                     mod_class_nodes = find_children(mod_document, ClassNode)
                     self._mod_update_class(class_nodes, mod_class_nodes)
                 else:
-                    raise ValueError(f"Modules to be updated are not found {mod_module_name}")
+                    raise ValueError(
+                        f"Modules to be updated are not found {mod_module_name}"
+                    )
             else:
-                raise NotImplementedError(f"ModTypeNode does not support {mod_type_node.astext()}")
+                raise NotImplementedError(
+                    f"ModTypeNode does not support {mod_type_node.astext()}"
+                )

--- a/src/fake_bpy_module/transformer/module_name_fixture.py
+++ b/src/fake_bpy_module/transformer/module_name_fixture.py
@@ -12,7 +12,6 @@ from .. import config
 
 
 class ModuleNameFixture(TransformerBase):
-
     def _no_module(self, document: nodes.document):
         module_node = get_first_child(document, ModuleNode)
         if module_node is not None:
@@ -23,7 +22,8 @@ class ModuleNameFixture(TransformerBase):
             if source_filename.startswith("bge.types."):
                 module_node = ModuleNode.create_template()
                 module_node.element(NameNode).add_text(
-                    os.path.splitext(os.path.basename(source_filename))[0])
+                    os.path.splitext(os.path.basename(source_filename))[0]
+                )
                 document.insert(0, module_node)
                 return False
 

--- a/src/fake_bpy_module/transformer/rst_specific_node_cleaner.py
+++ b/src/fake_bpy_module/transformer/rst_specific_node_cleaner.py
@@ -9,7 +9,6 @@ from ..utils import append_child
 
 
 class RstSpecificNodeCleaner(TransformerBase):
-
     def _replace(self, from_node: nodes.Node, to_node: nodes.Node):
         parent = from_node.parent
         index = from_node.parent.index(from_node)
@@ -27,7 +26,9 @@ class RstSpecificNodeCleaner(TransformerBase):
 
         # Make CodeDocumentNode from RST specific nodes.
         for node in document.children[:]:
-            if isinstance(node, (
+            if isinstance(
+                node,
+                (
                     nodes.title,
                     nodes.paragraph,
                     nodes.bullet_list,
@@ -41,7 +42,9 @@ class RstSpecificNodeCleaner(TransformerBase):
                     nodes.note,
                     nodes.warning,
                     nodes.target,
-                    CodeNode)):
+                    CodeNode,
+                ),
+            ):
                 code_doc_node = CodeDocumentNode()
                 self._replace(node, code_doc_node)
                 append_child(code_doc_node, node)

--- a/src/fake_bpy_module/transformer/same_module_merger.py
+++ b/src/fake_bpy_module/transformer/same_module_merger.py
@@ -11,7 +11,6 @@ from ..utils import get_first_child, append_child
 
 
 class SameModuleMerger(TransformerBase):
-
     def _merge(self, documents: List[nodes.document]) -> List[nodes.document]:
         module_to_documents = {}
         for document in documents:

--- a/src/fake_bpy_module/transformer/target_file_combiner.py
+++ b/src/fake_bpy_module/transformer/target_file_combiner.py
@@ -29,8 +29,10 @@ class GenerationInfo:
 
     def get(self, module_name: str) -> GenerationInfoByModule:
         if module_name not in self._info:
-            raise RuntimeError("Could not find module in GenerationInfoByModule "
-                               f"(module: {module_name})")
+            raise RuntimeError(
+                "Could not find module in GenerationInfoByModule "
+                f"(module: {module_name})"
+            )
         return self._info[module_name]
 
     def create(self, module_name: str) -> GenerationInfoByModule:
@@ -42,7 +44,6 @@ class GenerationInfo:
 
 
 class TargetFileCombiner(TransformerBase):
-
     def __init__(self, documents: List[nodes.document], **kwargs):
         super().__init__(documents, **kwargs)
         self._package_structure: ModuleStructure = None
@@ -50,31 +51,32 @@ class TargetFileCombiner(TransformerBase):
             self._package_structure = kwargs["package_structure"]
 
     def _build_generation_info(
-            self, documents: List[nodes.document],
-            module_structure: ModuleStructure) -> GenerationInfoByModule:
+        self, documents: List[nodes.document], module_structure: ModuleStructure
+    ) -> GenerationInfoByModule:
         def find_target_file(
-                name: str, structure: ModuleStructure, target: str,
-                module_level: int) -> str:
+            name: str, structure: ModuleStructure, target: str, module_level: int
+        ) -> str:
             for m in structure.children():
                 mod_name = name + m.name
                 if mod_name == target:
                     return mod_name + "/__init__"
 
                 if len(m.children()) > 0:
-                    ret = find_target_file(
-                        mod_name + "/", m, target, module_level+1)
+                    ret = find_target_file(mod_name + "/", m, target, module_level + 1)
                     if ret:
                         return ret
             return None
 
         def build_child_modules(
-                gen_info: GenerationInfo, name: str,
-                structure: ModuleStructure, module_level: int):
+            gen_info: GenerationInfo,
+            name: str,
+            structure: ModuleStructure,
+            module_level: int,
+        ):
             for m in structure.children():
                 mod_name = name + m.name
                 if len(m.children()) == 0:
-                    filename = \
-                        re.sub(r"\.", "/", mod_name) + "/__init__"
+                    filename = re.sub(r"\.", "/", mod_name) + "/__init__"
                     info = gen_info.create(mod_name)
                     info.documents = []
                     info.child_modules = []
@@ -85,8 +87,7 @@ class TargetFileCombiner(TransformerBase):
                     info.documents = []
                     info.child_modules = [child.name for child in m.children()]
                     info.target_filename = filename
-                    build_child_modules(
-                        gen_info, mod_name + ".", m, module_level+1)
+                    build_child_modules(gen_info, mod_name + ".", m, module_level + 1)
 
         # build child modules
         gen_info = GenerationInfo()
@@ -98,11 +99,13 @@ class TargetFileCombiner(TransformerBase):
             if module_node is None:
                 continue
             module_name = module_node.element(NameNode).astext()
-            target = find_target_file("", module_structure,
-                                      re.sub(r"\.", "/", module_name), 0)
+            target = find_target_file(
+                "", module_structure, re.sub(r"\.", "/", module_name), 0
+            )
             if target is None:
-                raise RuntimeError("Could not find target file to "
-                                   f"generate (target: {module_name})")
+                raise RuntimeError(
+                    "Could not find target file to " f"generate (target: {module_name})"
+                )
             info = gen_info.get(module_name)
             info.documents.append(document)
 

--- a/src/fake_bpy_module/transformer/transformer.py
+++ b/src/fake_bpy_module/transformer/transformer.py
@@ -20,37 +20,34 @@ from .target_file_combiner import TargetFileCombiner
 from .first_title_remover import FirstTitleRemover
 
 
-def transform(documents: List[nodes.document], mod_files: List[str]) -> List[nodes.document]:
-    t = Transformer([
-        # Must before base_class_fixture
-        "module_name_fixture",
-        "first_title_remover",
-        "rst_specific_node_cleaner",
-
-        "base_class_fixture",
-
-        # Must after base_class_fixture
-        "same_module_merger",
-        "module_level_attribute_fixture",
-        "bpy_module_tweaker",
-        "bpy_context_variable_converter",
-        "mod_applier",
-        "format_validator",
-
-        # Must after mod_applier
-        "target_file_combiner",
-        "data_type_refiner",
-
-        # Must after data_type_refiner
-        "default_value_filler",
-        "cannonical_data_type_rewriter",
-        "dependency_builder",
-        "code_document_refiner",
-    ], {
-        "mod_applier": {
-            "mod_files": mod_files
-        }
-    })
+def transform(
+    documents: List[nodes.document], mod_files: List[str]
+) -> List[nodes.document]:
+    t = Transformer(
+        [
+            # Must before base_class_fixture
+            "module_name_fixture",
+            "first_title_remover",
+            "rst_specific_node_cleaner",
+            "base_class_fixture",
+            # Must after base_class_fixture
+            "same_module_merger",
+            "module_level_attribute_fixture",
+            "bpy_module_tweaker",
+            "bpy_context_variable_converter",
+            "mod_applier",
+            "format_validator",
+            # Must after mod_applier
+            "target_file_combiner",
+            "data_type_refiner",
+            # Must after data_type_refiner
+            "default_value_filler",
+            "cannonical_data_type_rewriter",
+            "dependency_builder",
+            "code_document_refiner",
+        ],
+        {"mod_applier": {"mod_files": mod_files}},
+    )
     documents = t.transform(documents)
 
     return documents
@@ -67,8 +64,7 @@ class Transformer:
     def get_transformers(self) -> List[TransformerBase]:
         return self.transformers
 
-    def transform(self, documents: List[nodes.document],
-                  parameters: dict = None):
+    def transform(self, documents: List[nodes.document], parameters: dict = None):
         transformer_specs = {
             BaseClassFixture.name(): {
                 "class": BaseClassFixture,

--- a/src/fake_bpy_module/transformer/transformer_base.py
+++ b/src/fake_bpy_module/transformer/transformer_base.py
@@ -3,7 +3,6 @@ from docutils import nodes
 
 
 class TransformerBase:
-
     # pylint: disable=W0613
     def __init__(self, documents: List[nodes.document], **kwargs):
         self.documents: List[nodes.document] = documents

--- a/src/fake_bpy_module/transformer/utils.py
+++ b/src/fake_bpy_module/transformer/utils.py
@@ -89,8 +89,8 @@ def get_module_name(data_type: str, module_structure: ModuleStructure) -> str:
     module_names = data_type.split(".")[:-1]
 
     def search(
-            mod_names, structure: ModuleStructure, dtype: str,
-            is_first_level: bool = False):
+        mod_names, structure: ModuleStructure, dtype: str, is_first_level: bool = False
+    ):
         if len(mod_names) == 0:
             return dtype
         for s in structure.children():

--- a/src/fake_bpy_module/utils.py
+++ b/src/fake_bpy_module/utils.py
@@ -87,8 +87,7 @@ def split_string_by_comma(line: str) -> list:
         elif c in (")", "}", "]"):
             level -= 1
             if level < 0:
-                raise ValueError(
-                    f"Level must be >= 0 but {level} (Line: {line})")
+                raise ValueError(f"Level must be >= 0 but {level} (Line: {line})")
         if level == 0 and c == ",":
             splited.append(current)
             current = ""
@@ -96,8 +95,7 @@ def split_string_by_comma(line: str) -> list:
             current += c
 
     if level != 0:
-        raise ValueError(
-            f"Level must be == 0 but {level} (Line: {line})")
+        raise ValueError(f"Level must be == 0 but {level} (Line: {line})")
 
     if current != "":
         splited.append(current)

--- a/src/gen.py
+++ b/src/gen.py
@@ -20,36 +20,33 @@ def generate(target_files: List[str], mod_files: List[str]):
 def parse_options():
     # pylint: disable=W0603
     global INPUT_DIR  # pylint: disable=W0602
-    usage = f"Usage: python {__file__} [-i <input_dir>] [-o <output_dir>] " \
-            "[-T <target>] [-t <target_version>] [-d] [-f <style_format>] " \
-            "[-m <mod_version>]"
+    usage = (
+        f"Usage: python {__file__} [-i <input_dir>] [-o <output_dir>] "
+        "[-T <target>] [-t <target_version>] [-d] [-f <style_format>] "
+        "[-m <mod_version>]"
+    )
     parser = argparse.ArgumentParser(usage)
+    parser.add_argument("-i", dest="input_dir", type=str, help="Input directory")
+    parser.add_argument("-o", dest="output_dir", type=str, help="Output directory")
     parser.add_argument(
-        "-i", dest="input_dir", type=str, help="Input directory"
+        "-f", dest="style_format", type=str, help="Style format (none, yapf, ruff)"
     )
     parser.add_argument(
-        "-o", dest="output_dir", type=str, help="Output directory"
-    )
-    parser.add_argument(
-        "-f", dest="style_format", type=str,
-        help="Style format (none, yapf, ruff)"
-    )
-    parser.add_argument(
-        "-m", dest="mod_version", type=str,
+        "-m",
+        dest="mod_version",
+        type=str,
         help="Blender version for specific mod patches to be applied "
-             "(ex. 2.79, 2.80)"
+        "(ex. 2.79, 2.80)",
+    )
+    parser.add_argument("-T", dest="target", type=str, help="Target (blender, upbge)")
+    parser.add_argument(
+        "-t", dest="target_version", type=str, help="Target version (ex. 2.79, 2.80)"
     )
     parser.add_argument(
-        "-T", dest="target", type=str,
-        help="Target (blender, upbge)"
-    )
-    parser.add_argument(
-        "-t", dest="target_version", type=str,
-        help="Target version (ex. 2.79, 2.80)"
-    )
-    parser.add_argument(
-        "-l", dest="output_log_level", type=str,
-        help="Output log level (debug, info, notice, warn, err"
+        "-l",
+        dest="output_log_level",
+        type=str,
+        help="Output log level (debug, info, notice, warn, err",
     )
     args = parser.parse_args()
     if args.input_dir:
@@ -62,14 +59,16 @@ def parse_options():
     else:
         raise RuntimeError(
             f"Not supported style format {args.style_format}. "
-            f"(Supported Style Format: {fbm.support.SUPPORTED_STYLE_FORMAT})")
+            f"(Supported Style Format: {fbm.support.SUPPORTED_STYLE_FORMAT})"
+        )
 
     if args.target in fbm.support.SUPPORTED_TARGET:
         fbm.config.set_target(args.target)
     else:
         raise RuntimeError(
             f"Not supported target {args.target}."
-            f"(Supported Target: {fbm.support.SUPPORTED_TARGET})")
+            f"(Supported Target: {fbm.support.SUPPORTED_TARGET})"
+        )
 
     if args.target == "blender":
         if args.target_version in fbm.support.SUPPORTED_BLENDER_VERSION:
@@ -78,7 +77,8 @@ def parse_options():
             raise RuntimeError(
                 f"Not supported blender version {args.target_version}. "
                 f"(Supported Version: "
-                f"{fbm.support.SUPPORTED_BLENDER_VERSION})")
+                f"{fbm.support.SUPPORTED_BLENDER_VERSION})"
+            )
 
     if args.target == "upbge":
         if args.target_version in fbm.support.SUPPORTED_UPBGE_VERSION:
@@ -86,7 +86,8 @@ def parse_options():
         else:
             raise RuntimeError(
                 f"Not supported upbge version {args.target_version}. "
-                f"(Supported Version: {fbm.support.SUPPORTED_UPBGE_VERSION})")
+                f"(Supported Version: {fbm.support.SUPPORTED_UPBGE_VERSION})"
+            )
 
     if args.mod_version:
         if fbm.config.get_target() == "blender":
@@ -96,7 +97,8 @@ def parse_options():
                 raise RuntimeError(
                     f"Not supported mod version {args.mod_version}. "
                     f"(Supported Version: "
-                    f"{fbm.support.SUPPORTED_MOD_BLENDER_VERSION})")
+                    f"{fbm.support.SUPPORTED_MOD_BLENDER_VERSION})"
+                )
         elif fbm.config.get_target() == "upbge":
             if args.mod_version in fbm.support.SUPPORTED_MOD_UPBGE_VERSION:
                 fbm.config.set_mod_version(args.mod_version)
@@ -104,7 +106,8 @@ def parse_options():
                 raise RuntimeError(
                     f"Not supported mod version {args.mod_version}. "
                     f"(Supported Version: "
-                    f"{fbm.support.SUPPORTED_MOD_UPBGE_VERSION})")
+                    f"{fbm.support.SUPPORTED_MOD_UPBGE_VERSION})"
+                )
 
     if args.output_log_level:
         ARG_TO_LOG_LEVEL = {
@@ -122,27 +125,41 @@ def collect_files() -> Tuple[str, str]:
     rst_files = glob.glob(f"{INPUT_DIR}/**/*.rst", recursive=True)
 
     # Collect all mod files.
-    mod_files = glob.glob(f"{MOD_FILES_DIR}/mods/generated_mods/**/*.mod.rst", recursive=True)
+    mod_files = glob.glob(
+        f"{MOD_FILES_DIR}/mods/generated_mods/**/*.mod.rst", recursive=True
+    )
     mod_files += glob.glob(f"{MOD_FILES_DIR}/mods/common/**/*.mod.rst", recursive=True)
-    if fbm.config.get_target() == "blender" and fbm.config.get_mod_version() in ["2.78", "2.79"]:
-        mod_files += glob.glob(f"{MOD_FILES_DIR}/mods/{fbm.config.get_mod_version()}/**/*.mod.rst",
-                               recursive=True)
+    if fbm.config.get_target() == "blender" and fbm.config.get_mod_version() in [
+        "2.78",
+        "2.79",
+    ]:
+        mod_files += glob.glob(
+            f"{MOD_FILES_DIR}/mods/{fbm.config.get_mod_version()}/**/*.mod.rst",
+            recursive=True,
+        )
     # Remove unnecessary mod files.
     mod_files = set(mod_files)
     if fbm.config.get_target() == "blender":
         if fbm.config.get_mod_version() not in ["2.78", "2.79"]:
-            mod_files -= set(glob.glob(
-                f"{MOD_FILES_DIR}/mods/generated_mods/gen_modules_modfile/gpu_extras.*.mod.rst"
-            ))
+            mod_files -= set(
+                glob.glob(
+                    f"{MOD_FILES_DIR}/mods/generated_mods/gen_modules_modfile/gpu_extras.*.mod.rst"
+                )
+            )
         if fbm.config.get_mod_version() in ["2.78", "2.79"]:
-            mod_files -= set(glob.glob(
-                f"{MOD_FILES_DIR}/mods/common/**/bpy.app.timers.mod.rst", recursive=True
-            ))
+            mod_files -= set(
+                glob.glob(
+                    f"{MOD_FILES_DIR}/mods/common/**/bpy.app.timers.mod.rst",
+                    recursive=True,
+                )
+            )
     elif fbm.config.get_target() == "upbge":
         if fbm.config.get_mod_version() not in ["0.2.5"]:
-            mod_files -= set(glob.glob(
-                f"{MOD_FILES_DIR}/mods/generated_mods/gen_modules_modfile/gpu_extras.*.mod.rst"
-            ))
+            mod_files -= set(
+                glob.glob(
+                    f"{MOD_FILES_DIR}/mods/generated_mods/gen_modules_modfile/gpu_extras.*.mod.rst"
+                )
+            )
     # TODO: sorted() is needed to solve unexpected errors.
     #       The error comes from the invalid processes in mod_applier when there are
     #       more than 2 mod files targeted for the same module.

--- a/src/gen_modfile/gen_bgl_modfile.py
+++ b/src/gen_modfile/gen_bgl_modfile.py
@@ -75,7 +75,7 @@ def get_function_info(line: str) -> Dict:
         return {
             "func_name": f"gl{func_name}",
             "return_type": return_type,
-            "arg_types": args_list[1:-1].split(",")
+            "arg_types": args_list[1:-1].split(","),
         }
 
     return None
@@ -125,26 +125,24 @@ def gltype_to_pytype(gltype: str) -> str:
     return type_map[gltype]
 
 
-def create_function_def(
-        func_name: str, return_type: str, arg_types: List[str]) -> Dict:
+def create_function_def(func_name: str, return_type: str, arg_types: List[str]) -> Dict:
     function_def = {
         "name": func_name,
         "type": "function",
         "module": "bgl",
-        "return": {
-            "type": "return",
-            "data_type": gltype_to_pytype(return_type)
-        },
+        "return": {"type": "return", "data_type": gltype_to_pytype(return_type)},
         "parameters": [],
         "parameter_details": [],
     }
     for i, arg_type in enumerate(arg_types):
         function_def["parameters"].append(f"p{i}")
-        function_def["parameter_details"].append({
-            "name": f"p{i}",
-            "type": "parameter",
-            "data_type": gltype_to_pytype(arg_type)
-        })
+        function_def["parameter_details"].append(
+            {
+                "name": f"p{i}",
+                "type": "parameter",
+                "data_type": gltype_to_pytype(arg_type),
+            }
+        )
 
     return function_def
 
@@ -181,9 +179,13 @@ def analyze(config: 'GenerationConfig') -> Dict:
     for const in const_lists:
         data["new"].append(create_constant_def(const))
     for func in func_lists:
-        data["new"].append(create_function_def(func_info[func]["func_name"],
-                                               func_info[func]["return_type"],
-                                               func_info[func]["arg_types"]))
+        data["new"].append(
+            create_function_def(
+                func_info[func]["func_name"],
+                func_info[func]["return_type"],
+                func_info[func]["arg_types"],
+            )
+        )
 
     return data
 
@@ -191,15 +193,18 @@ def analyze(config: 'GenerationConfig') -> Dict:
 def parse_options() -> 'GenerationConfig':
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-i", dest="bgl_c_file", type=str, help="Path to bgl.c",
-        required=True
+        "-i", dest="bgl_c_file", type=str, help="Path to bgl.c", required=True
     )
     parser.add_argument(
-        "-o", dest="output_file", type=str, help="Output directory",
-        required=True
+        "-o", dest="output_file", type=str, help="Output directory", required=True
     )
-    parser.add_argument("-f", dest="output_format", type=str,
-                        help="Output format (rst, json).", required=True)
+    parser.add_argument(
+        "-f",
+        dest="output_format",
+        type=str,
+        help="Output format (rst, json).",
+        required=True,
+    )
     args = parser.parse_args()
 
     config = GenerationConfig()
@@ -220,10 +225,14 @@ def write_to_rst_modfile(data: Dict, config: 'GenerationConfig'):
         for info in data["new"]:
             if info["type"] == "function":
                 func_info = info
-                f.write(f".. function:: {func_info['name']}"
-                        f"({', '.join(func_info['parameters'])})\n\n")
+                f.write(
+                    f".. function:: {func_info['name']}"
+                    f"({', '.join(func_info['parameters'])})\n\n"
+                )
                 for param_info in func_info["parameter_details"]:
-                    f.write(f"   :type {param_info['name']}: {param_info['data_type']}\n")
+                    f.write(
+                        f"   :type {param_info['name']}: {param_info['data_type']}\n"
+                    )
                 if func_info["return"]["data_type"] == "":
                     f.write("\n")
                 else:

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
 yapf==0.25.0
-ruff==0.1.9
+ruff==0.4.5
 docutils==0.20.1
 Pygments==2.17.2

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/analyzer_test.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/analyzer_test.py
@@ -8,11 +8,11 @@ from . import common
 
 
 class BaseAnalyzerTest(common.FakeBpyModuleTestBase):
-
     name = "BaseAnalyzerTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/analyzer_test_data/base_analyzer_test")
+        f"{os.path.dirname(__file__)}/analyzer_test_data/base_analyzer_test"
+    )
 
     def setUp(self):
         super().setUp()

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/common.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/common.py
@@ -5,7 +5,6 @@ LOG_DIR = "fake_bpy_module_test.log"
 
 
 class FakeBpyModuleTestBase(unittest.TestCase):
-
     name = None
     module_name = None
     log_dir = None
@@ -22,14 +21,14 @@ class FakeBpyModuleTestBase(unittest.TestCase):
         os.makedirs(cls.log_dir, exist_ok=True)
 
         filename = f"{cls.log_dir}/{cls.name}.log"
-        cls.file_ = open(filename, "w", encoding="utf-8")   # noqa # pylint: disable=R1732
+        cls.file_ = open(filename, "w", encoding="utf-8")  # noqa # pylint: disable=R1732
 
     @classmethod
     def tearDownClass(cls):
         cls.file_.close()
 
     def setUp(self):
-        self.maxDiff = None     # pylint: disable=C0103
+        self.maxDiff = None  # pylint: disable=C0103
         self.log(f"========== Test: {self.id()} ==========")
 
     def tearDown(self):

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test.py
@@ -3,27 +3,26 @@ import os
 from docutils import nodes
 from docutils.core import publish_doctree
 
-from fake_bpy_module.analyzer.analyzer import BaseAnalyzer      # pylint: disable=E0401
-from fake_bpy_module.transformer.transformer import Transformer     # pylint: disable=E0401
-from fake_bpy_module.transformer.utils import ModuleStructure       # pylint: disable=E0401
-from fake_bpy_module.generator.writers import (     # pylint: disable=E0401
+from fake_bpy_module.analyzer.analyzer import BaseAnalyzer  # pylint: disable=E0401
+from fake_bpy_module.transformer.transformer import Transformer  # pylint: disable=E0401
+from fake_bpy_module.transformer.utils import ModuleStructure  # pylint: disable=E0401
+from fake_bpy_module.generator.writers import (  # pylint: disable=E0401
     sorted_entry_point_nodes,
     BaseWriter,
     PyCodeWriter,
     PyInterfaceWriter,
     JsonWriter,
 )
-from fake_bpy_module.generator.code_writer import (     # pylint: disable=E0401
+from fake_bpy_module.generator.code_writer import (  # pylint: disable=E0401
     CodeWriterIndent,
     CodeWriter,
 )
 from fake_bpy_module import config  # pylint: disable=E0401
-from fake_bpy_module.utils import append_child      # pylint: disable=E0401
+from fake_bpy_module.utils import append_child  # pylint: disable=E0401
 from . import common
 
 
 class CodeWriterIndentTest(common.FakeBpyModuleTestBase):
-
     name = "CodeWriterIndentTest"
     module_name = __module__
 
@@ -79,11 +78,11 @@ class CodeWriterIndentTest(common.FakeBpyModuleTestBase):
 
 
 class CodeWriterTest(common.FakeBpyModuleTestBase):
-
     name = "CodeWriterTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/generator_test_data/code_writer_test")
+        f"{os.path.dirname(__file__)}/generator_test_data/code_writer_test"
+    )
 
     def setUp(self):
         super().setUp()
@@ -98,8 +97,7 @@ class CodeWriterTest(common.FakeBpyModuleTestBase):
         shutil.rmtree(self.output_dir)
 
     def test_normal(self):
-        with open(self.output_file_path, "w", newline="\n",
-                  encoding="utf-8") as f:
+        with open(self.output_file_path, "w", newline="\n", encoding="utf-8") as f:
             writer = CodeWriter()
 
             writer.addln("import module_1")
@@ -122,8 +120,7 @@ class CodeWriterTest(common.FakeBpyModuleTestBase):
         self.assertEqual(expect_contents, actual_contents)
 
     def test_with_code_indent(self):
-        with open(self.output_file_path, "w", newline="\n",
-                  encoding="utf-8") as f:
+        with open(self.output_file_path, "w", newline="\n", encoding="utf-8") as f:
             writer = CodeWriter()
 
             writer.addln("import module_1")
@@ -137,8 +134,7 @@ class CodeWriterTest(common.FakeBpyModuleTestBase):
             writer.format(style_config="ruff", file_format="py")
             writer.write(f)
 
-        expect_file_path = \
-            f"{self.data_dir}/code_writer_test_with_code_indent.py"
+        expect_file_path = f"{self.data_dir}/code_writer_test_with_code_indent.py"
         actual_file_path = self.output_file_path
         with open(actual_file_path, "r", encoding="utf-8") as f:
             expect_contents = f.read()
@@ -151,8 +147,7 @@ class CodeWriterTest(common.FakeBpyModuleTestBase):
         self.assertEqual(expect_contents, actual_contents)
 
     def test_with_reset(self):
-        with open(self.output_file_path, "w", newline="\n",
-                  encoding="utf-8") as f:
+        with open(self.output_file_path, "w", newline="\n", encoding="utf-8") as f:
             writer = CodeWriter()
 
             writer.addln("import fake")
@@ -196,11 +191,11 @@ i: int = 10
 
 
 class SortedEntryPointNodesTest(common.FakeBpyModuleTestBase):
-
     name = "SortedEntryPointNodesTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/generator_test_data/sorted_entry_point_nodes_test")
+        f"{os.path.dirname(__file__)}/generator_test_data/sorted_entry_point_nodes_test"
+    )
 
     def setUp(self):
         super().setUp()
@@ -221,8 +216,12 @@ class SortedEntryPointNodesTest(common.FakeBpyModuleTestBase):
         expect_analyzed_files = ["basic.xml"]
         expect_sorted_files = ["basic_sorted.xml"]
         rst_files = [f"{self.data_dir}/input/basic/{f}" for f in rst_files]
-        expect_analyzed_files = [f"{self.data_dir}/expect/basic/{f}" for f in expect_analyzed_files]
-        expect_sorted_files = [f"{self.data_dir}/expect/basic/{f}" for f in expect_sorted_files]
+        expect_analyzed_files = [
+            f"{self.data_dir}/expect/basic/{f}" for f in expect_analyzed_files
+        ]
+        expect_sorted_files = [
+            f"{self.data_dir}/expect/basic/{f}" for f in expect_sorted_files
+        ]
 
         # Analyze
         analyzer = BaseAnalyzer()
@@ -245,11 +244,17 @@ class SortedEntryPointNodesTest(common.FakeBpyModuleTestBase):
         rst_files = ["high_priority_class.rst"]
         expect_analyzed_files = ["high_priority_class.xml"]
         expect_sorted_files = ["high_priority_class_sorted.xml"]
-        rst_files = [f"{self.data_dir}/input/high_priority_class/{f}" for f in rst_files]
-        expect_analyzed_files = [f"{self.data_dir}/expect/high_priority_class/{f}"
-                                 for f in expect_analyzed_files]
-        expect_sorted_files = [f"{self.data_dir}/expect/high_priority_class/{f}"
-                               for f in expect_sorted_files]
+        rst_files = [
+            f"{self.data_dir}/input/high_priority_class/{f}" for f in rst_files
+        ]
+        expect_analyzed_files = [
+            f"{self.data_dir}/expect/high_priority_class/{f}"
+            for f in expect_analyzed_files
+        ]
+        expect_sorted_files = [
+            f"{self.data_dir}/expect/high_priority_class/{f}"
+            for f in expect_sorted_files
+        ]
 
         # Analyze
         analyzer = BaseAnalyzer()
@@ -272,11 +277,17 @@ class SortedEntryPointNodesTest(common.FakeBpyModuleTestBase):
         rst_files = ["base_class_dependency.rst"]
         expect_analyzed_files = ["base_class_dependency.xml"]
         expect_sorted_files = ["base_class_dependency_sorted.xml"]
-        rst_files = [f"{self.data_dir}/input/base_class_dependency/{f}" for f in rst_files]
-        expect_analyzed_files = [f"{self.data_dir}/expect/base_class_dependency/{f}"
-                                 for f in expect_analyzed_files]
-        expect_sorted_files = [f"{self.data_dir}/expect/base_class_dependency/{f}"
-                               for f in expect_sorted_files]
+        rst_files = [
+            f"{self.data_dir}/input/base_class_dependency/{f}" for f in rst_files
+        ]
+        expect_analyzed_files = [
+            f"{self.data_dir}/expect/base_class_dependency/{f}"
+            for f in expect_analyzed_files
+        ]
+        expect_sorted_files = [
+            f"{self.data_dir}/expect/base_class_dependency/{f}"
+            for f in expect_sorted_files
+        ]
 
         # Analyze
         analyzer = BaseAnalyzer()
@@ -297,11 +308,11 @@ class SortedEntryPointNodesTest(common.FakeBpyModuleTestBase):
 
 
 class WriterTestBase(common.FakeBpyModuleTestBase):
-
     name = "WriterTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/generator_test_data/py_code_writer_test")
+        f"{os.path.dirname(__file__)}/generator_test_data/py_code_writer_test"
+    )
     writer_class: type[BaseWriter] = BaseWriter
     file_extension: str = ""
     output_file: str = "py_code_writer_test_output"
@@ -328,9 +339,12 @@ class WriterTestBase(common.FakeBpyModuleTestBase):
         expect_analyzed_files = ["class.xml"]
         expect_generated_files = [f"class.{self.file_extension}"]
         rst_files = [f"{self.data_dir}/input/class/{f}" for f in rst_files]
-        expect_analyzed_files = [f"{self.data_dir}/expect/class/{f}" for f in expect_analyzed_files]
-        expect_generated_files = [f"{self.data_dir}/expect/class/{f}"
-                                  for f in expect_generated_files]
+        expect_analyzed_files = [
+            f"{self.data_dir}/expect/class/{f}" for f in expect_analyzed_files
+        ]
+        expect_generated_files = [
+            f"{self.data_dir}/expect/class/{f}" for f in expect_generated_files
+        ]
 
         # Analyze
         analyzer = BaseAnalyzer()
@@ -361,10 +375,12 @@ class WriterTestBase(common.FakeBpyModuleTestBase):
         expect_analyzed_files = ["function.xml"]
         expect_generated_files = [f"function.{self.file_extension}"]
         rst_files = [f"{self.data_dir}/input/function/{f}" for f in rst_files]
-        expect_analyzed_files = [f"{self.data_dir}/expect/function/{f}"
-                                 for f in expect_analyzed_files]
-        expect_generated_files = [f"{self.data_dir}/expect/function/{f}"
-                                  for f in expect_generated_files]
+        expect_analyzed_files = [
+            f"{self.data_dir}/expect/function/{f}" for f in expect_analyzed_files
+        ]
+        expect_generated_files = [
+            f"{self.data_dir}/expect/function/{f}" for f in expect_generated_files
+        ]
 
         # Analyze
         analyzer = BaseAnalyzer()
@@ -395,9 +411,12 @@ class WriterTestBase(common.FakeBpyModuleTestBase):
         expect_analyzed_files = ["data.xml"]
         expect_generated_files = [f"data.{self.file_extension}"]
         rst_files = [f"{self.data_dir}/input/data/{f}" for f in rst_files]
-        expect_analyzed_files = [f"{self.data_dir}/expect/data/{f}" for f in expect_analyzed_files]
-        expect_generated_files = [f"{self.data_dir}/expect/data/{f}"
-                                  for f in expect_generated_files]
+        expect_analyzed_files = [
+            f"{self.data_dir}/expect/data/{f}" for f in expect_analyzed_files
+        ]
+        expect_generated_files = [
+            f"{self.data_dir}/expect/data/{f}" for f in expect_generated_files
+        ]
 
         # Analyze
         analyzer = BaseAnalyzer()
@@ -429,12 +448,15 @@ class WriterTestBase(common.FakeBpyModuleTestBase):
         expect_transformed_files = ["dependencies_transformed.xml"]
         expect_generated_files = [f"dependencies.{self.file_extension}"]
         rst_files = [f"{self.data_dir}/input/dependencies/{f}" for f in rst_files]
-        expect_analyzed_files = [f"{self.data_dir}/expect/dependencies/{f}"
-                                 for f in expect_analyzed_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/dependencies/{f}"
-                                    for f in expect_transformed_files]
-        expect_generated_files = [f"{self.data_dir}/expect/dependencies/{f}"
-                                  for f in expect_generated_files]
+        expect_analyzed_files = [
+            f"{self.data_dir}/expect/dependencies/{f}" for f in expect_analyzed_files
+        ]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/dependencies/{f}" for f in expect_transformed_files
+        ]
+        expect_generated_files = [
+            f"{self.data_dir}/expect/dependencies/{f}" for f in expect_generated_files
+        ]
 
         # Analyze
         analyzer = BaseAnalyzer()
@@ -453,13 +475,12 @@ class WriterTestBase(common.FakeBpyModuleTestBase):
         module_2_structure.name = "module_2"
         package_structure.add_child(module_2_structure)
 
-        transformer = Transformer([
-            "dependency_builder",
-        ], {
-            "dependency_builder": {
-                "package_structure": package_structure
-            }
-        })
+        transformer = Transformer(
+            [
+                "dependency_builder",
+            ],
+            {"dependency_builder": {"package_structure": package_structure}},
+        )
         documents = transformer.transform(documents)
 
         self.assertEqual(len(documents), len(expect_transformed_files))
@@ -487,19 +508,22 @@ class WriterTestBase(common.FakeBpyModuleTestBase):
         expect_analyzed_files = ["children.xml"]
         expect_transformed_files = [
             "module_1_transformed.xml",
-            "module_1.submodule_1_transformed.xml"
+            "module_1.submodule_1_transformed.xml",
         ]
         expect_generated_files = [
             f"module_1.{self.file_extension}",
-            f"module_1.submodule_1.{self.file_extension}"
+            f"module_1.submodule_1.{self.file_extension}",
         ]
         rst_files = [f"{self.data_dir}/input/children/{f}" for f in rst_files]
-        expect_analyzed_files = [f"{self.data_dir}/expect/children/{f}"
-                                 for f in expect_analyzed_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/children/{f}"
-                                    for f in expect_transformed_files]
-        expect_generated_files = [f"{self.data_dir}/expect/children/{f}"
-                                  for f in expect_generated_files]
+        expect_analyzed_files = [
+            f"{self.data_dir}/expect/children/{f}" for f in expect_analyzed_files
+        ]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/children/{f}" for f in expect_transformed_files
+        ]
+        expect_generated_files = [
+            f"{self.data_dir}/expect/children/{f}" for f in expect_generated_files
+        ]
 
         # Analyze
         analyzer = BaseAnalyzer()
@@ -518,13 +542,12 @@ class WriterTestBase(common.FakeBpyModuleTestBase):
         submodule_1_structure.name = "submodule_1"
         module_1_structure.add_child(submodule_1_structure)
 
-        transformer = Transformer([
-            "target_file_combiner",
-        ], {
-            "target_file_combiner": {
-                "package_structure": package_structure
-            }
-        })
+        transformer = Transformer(
+            [
+                "target_file_combiner",
+            ],
+            {"target_file_combiner": {"package_structure": package_structure}},
+        )
         documents = transformer.transform(documents)
 
         self.assertEqual(len(documents), len(expect_transformed_files))
@@ -552,10 +575,12 @@ class WriterTestBase(common.FakeBpyModuleTestBase):
         expect_analyzed_files = ["deprecated.xml"]
         expect_generated_files = [f"deprecated.{self.file_extension}"]
         rst_files = [f"{self.data_dir}/input/deprecated/{f}" for f in rst_files]
-        expect_analyzed_files = [f"{self.data_dir}/expect/deprecated/{f}"
-                                 for f in expect_analyzed_files]
-        expect_generated_files = [f"{self.data_dir}/expect/deprecated/{f}"
-                                  for f in expect_generated_files]
+        expect_analyzed_files = [
+            f"{self.data_dir}/expect/deprecated/{f}" for f in expect_analyzed_files
+        ]
+        expect_generated_files = [
+            f"{self.data_dir}/expect/deprecated/{f}" for f in expect_generated_files
+        ]
 
         # Analyze
         analyzer = BaseAnalyzer()
@@ -583,50 +608,52 @@ class WriterTestBase(common.FakeBpyModuleTestBase):
 
 
 class PyCodeWriterTest(WriterTestBase):
-
     name = "PyCodeWriterTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/generator_test_data/py_code_writer_test")
+        f"{os.path.dirname(__file__)}/generator_test_data/py_code_writer_test"
+    )
     writer_class: type[BaseWriter] = PyCodeWriter
     file_extension: str = "py"
     output_file: str = "py_code_writer_test_output"
 
 
 class PyInterfaceWriterTest(WriterTestBase):
-
     name = "PyInterfaceWriterTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/generator_test_data/py_interface_writer_test")
+        f"{os.path.dirname(__file__)}/generator_test_data/py_interface_writer_test"
+    )
     writer_class: type[BaseWriter] = PyInterfaceWriter
     file_extension: str = "pyi"
     output_file: str = "py_interface_writer_test_output"
 
 
 class JsonWriterTest(WriterTestBase):
-
     name = "JsonWriterTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/generator_test_data/json_writer_test")
+        f"{os.path.dirname(__file__)}/generator_test_data/json_writer_test"
+    )
     writer_class: type[BaseWriter] = JsonWriter
     file_extension: str = "json"
     output_file: str = "json_writer_test_output"
 
 
 class CodeDocumentNodeTranslatorTest(common.FakeBpyModuleTestBase):
-
     name = "CodeDocumentNodeTranslatorTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/generator_test_data/code_document_node_translator_test")
+        f"{os.path.dirname(__file__)}/generator_test_data/code_document_node_translator_test"
+    )
 
     def setUp(self):
         super().setUp()
 
         self.output_dir = "fake_bpy_module_test_tmp"
-        self.output_file_path = f"{self.output_dir}/code_document_node_translator_test_output"
+        self.output_file_path = (
+            f"{self.output_dir}/code_document_node_translator_test_output"
+        )
         os.makedirs(self.output_dir, exist_ok=False)
 
     def tearDown(self):
@@ -645,11 +672,15 @@ class CodeDocumentNodeTranslatorTest(common.FakeBpyModuleTestBase):
         expect_transformed_files = ["basic_transformed.xml"]
         expect_generated_files = ["basic.py"]
         rst_files = [f"{self.data_dir}/input/basic/{f}" for f in rst_files]
-        expect_analyzed_files = [f"{self.data_dir}/expect/basic/{f}" for f in expect_analyzed_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/basic/{f}"
-                                    for f in expect_transformed_files]
-        expect_generated_files = [f"{self.data_dir}/expect/basic/{f}"
-                                  for f in expect_generated_files]
+        expect_analyzed_files = [
+            f"{self.data_dir}/expect/basic/{f}" for f in expect_analyzed_files
+        ]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/basic/{f}" for f in expect_transformed_files
+        ]
+        expect_generated_files = [
+            f"{self.data_dir}/expect/basic/{f}" for f in expect_generated_files
+        ]
 
         # Analyze
         analyzer = BaseAnalyzer()
@@ -660,10 +691,12 @@ class CodeDocumentNodeTranslatorTest(common.FakeBpyModuleTestBase):
             self.compare_with_file_contents(doc.pformat(), expect)
 
         # Transform
-        transformer = Transformer([
-            "rst_specific_node_cleaner",
-            "code_document_refiner",
-        ])
+        transformer = Transformer(
+            [
+                "rst_specific_node_cleaner",
+                "code_document_refiner",
+            ]
+        )
         documents = transformer.transform(documents)
 
         self.assertEqual(len(documents), len(expect_transformed_files))

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test.py
@@ -1,19 +1,19 @@
 import shutil
 import os
 
-from fake_bpy_module.analyzer.analyzer import analyze   # pylint: disable=E0401
-from fake_bpy_module.transformer.transformer import transform   # pylint: disable=E0401
-from fake_bpy_module.generator.generator import generate    # pylint: disable=E0401
+from fake_bpy_module.analyzer.analyzer import analyze  # pylint: disable=E0401
+from fake_bpy_module.transformer.transformer import transform  # pylint: disable=E0401
+from fake_bpy_module.generator.generator import generate  # pylint: disable=E0401
 from fake_bpy_module import config  # pylint: disable=E0401
 from . import common
 
 
 class IntegrationTest(common.FakeBpyModuleTestBase):
-
     name = "IntegrationTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/integration_test_data/integration_test")
+        f"{os.path.dirname(__file__)}/integration_test_data/integration_test"
+    )
 
     def setUp(self):
         super().setUp()

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test.py
@@ -18,7 +18,6 @@ from . import common
 
 
 class TransformerTestBase(common.FakeBpyModuleTestBase):
-
     def setUp(self):
         super().setUp()
 
@@ -35,11 +34,11 @@ class TransformerTestBase(common.FakeBpyModuleTestBase):
 
 
 class BaseClassFixtureTest(TransformerTestBase):
-
     name = "BaseClassFixtureTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/base_class_fixture_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/base_class_fixture_test"
+    )
 
     def test_basic(self):
         rst_files = ["basic.rst"]
@@ -47,7 +46,9 @@ class BaseClassFixtureTest(TransformerTestBase):
         expect_transformed_files = ["basic_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -65,11 +66,11 @@ class BaseClassFixtureTest(TransformerTestBase):
 
 
 class ModuleLevelAttributeFixtureTest(TransformerTestBase):
-
     name = "ModuleLevelAttributeFixtureTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/module_level_attribute_fixture_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/module_level_attribute_fixture_test"
+    )
 
     def test_basic(self):
         rst_files = ["basic.rst"]
@@ -77,7 +78,9 @@ class ModuleLevelAttributeFixtureTest(TransformerTestBase):
         expect_transformed_files = ["basic_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -95,11 +98,11 @@ class ModuleLevelAttributeFixtureTest(TransformerTestBase):
 
 
 class ModuleNameFixtureTest(TransformerTestBase):
-
     name = "ModuleNameFixtureTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/module_name_fixture_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/module_name_fixture_test"
+    )
 
     def test_no_module(self):
         rst_files = ["no_module.rst"]
@@ -107,7 +110,9 @@ class ModuleNameFixtureTest(TransformerTestBase):
         expect_transformed_files = []
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -129,7 +134,9 @@ class ModuleNameFixtureTest(TransformerTestBase):
         expect_transformed_files = ["bge.types.NoModule_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         config.set_target("upbge")
@@ -149,11 +156,11 @@ class ModuleNameFixtureTest(TransformerTestBase):
 
 
 class RstSpecificNodeCleanerTest(TransformerTestBase):
-
     name = "RstSpecificNodeCleanerTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/rst_specific_node_cleaner_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/rst_specific_node_cleaner_test"
+    )
 
     def test_basic(self):
         rst_files = ["basic.rst"]
@@ -161,7 +168,9 @@ class RstSpecificNodeCleanerTest(TransformerTestBase):
         expect_transformed_files = ["basic_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -179,7 +188,6 @@ class RstSpecificNodeCleanerTest(TransformerTestBase):
 
 
 class FormatValidatorTest(TransformerTestBase):
-
     name = "FormatValidatorTest"
     module_name = __module__
 
@@ -197,30 +205,24 @@ class FormatValidatorTest(TransformerTestBase):
 
 
 class BpyContextVariableConverterTest(TransformerTestBase):
-
     name = "BpyContextVariableConverterTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/bpy_context_variable_converter_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/bpy_context_variable_converter_test"
+    )
 
     def test_basic(self):
-        rst_files = [
-            "basic_1.rst",
-            "basic_2.rst",
-            "basic_3.rst"
-        ]
-        expect_files = [
-            "basic_1.xml",
-            "basic_2.xml",
-            "basic_3.xml"
-        ]
+        rst_files = ["basic_1.rst", "basic_2.rst", "basic_3.rst"]
+        expect_files = ["basic_1.xml", "basic_2.xml", "basic_3.xml"]
         expect_transformed_files = [
             "basic_transformed_1.xml",
-            "basic_transformed_2.xml"
+            "basic_transformed_2.xml",
         ]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -238,20 +240,23 @@ class BpyContextVariableConverterTest(TransformerTestBase):
 
 
 class BpyModuleTweakerTest(TransformerTestBase):
-
     name = "BpyModuleTweakerTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/"
-        "bpy_module_tweaker")
+        f"{os.path.dirname(__file__)}/transformer_test_data/" "bpy_module_tweaker"
+    )
 
     def test_make_bpy_prop_functions_arguments_kwonlyargs(self):
         rst_files = ["make_bpy_prop_functions_arguments_kwonlyargs.rst"]
         expect_files = ["make_bpy_prop_functions_arguments_kwonlyargs.xml"]
-        expect_transformed_files = ["make_bpy_prop_functions_arguments_kwonlyargs_transformed.xml"]
+        expect_transformed_files = [
+            "make_bpy_prop_functions_arguments_kwonlyargs_transformed.xml"
+        ]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -270,10 +275,14 @@ class BpyModuleTweakerTest(TransformerTestBase):
     def test_add_bpy_app_handlers_functions_data_types(self):
         rst_files = ["add_bpy_app_handlers_functions_data_types.rst"]
         expect_files = ["add_bpy_app_handlers_functions_data_types.xml"]
-        expect_transformed_files = ["add_bpy_app_handlers_functions_data_types_transformed.xml"]
+        expect_transformed_files = [
+            "add_bpy_app_handlers_functions_data_types_transformed.xml"
+        ]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -295,7 +304,9 @@ class BpyModuleTweakerTest(TransformerTestBase):
         expect_transformed_files = ["add_bpy_ops_override_parameters_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -317,7 +328,9 @@ class BpyModuleTweakerTest(TransformerTestBase):
         expect_transformed_files = ["rebase_bpy_types_class_base_class_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -335,11 +348,11 @@ class BpyModuleTweakerTest(TransformerTestBase):
 
 
 class CannonicalDataTypeRewriterTest(TransformerTestBase):
-
     name = "CannonicalDataTypeRewriterTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/cannonical_data_type_rewriter_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/cannonical_data_type_rewriter_test"
+    )
 
     def test_basic(self):
         rst_files = ["basic.rst"]
@@ -347,7 +360,9 @@ class CannonicalDataTypeRewriterTest(TransformerTestBase):
         expect_transformed_files = ["basic_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -375,11 +390,14 @@ class CannonicalDataTypeRewriterTest(TransformerTestBase):
         for doc, expect in zip(documents, expect_files):
             self.compare_with_file_contents(doc.pformat(), expect)
 
-        transformer = Transformer(["cannonical_data_type_rewriter"], {
-            "cannonical_data_type_rewriter": {
-                "package_structure": package_structure,
-            }
-        })
+        transformer = Transformer(
+            ["cannonical_data_type_rewriter"],
+            {
+                "cannonical_data_type_rewriter": {
+                    "package_structure": package_structure,
+                }
+            },
+        )
         transformed = transformer.transform(documents)
 
         self.assertEqual(len(transformed), len(expect_transformed_files))
@@ -388,11 +406,11 @@ class CannonicalDataTypeRewriterTest(TransformerTestBase):
 
 
 class CodeDocumentRefinerTest(TransformerTestBase):
-
     name = "CodeDocumentRefinerTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/code_document_refiner_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/code_document_refiner_test"
+    )
 
     def test_merge(self):
         rst_files = ["merge.rst"]
@@ -400,7 +418,9 @@ class CodeDocumentRefinerTest(TransformerTestBase):
         expect_transformed_files = ["merge_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -409,10 +429,12 @@ class CodeDocumentRefinerTest(TransformerTestBase):
         for doc, expect in zip(documents, expect_files):
             self.compare_with_file_contents(doc.pformat(), expect)
 
-        transformer = Transformer([
-            "rst_specific_node_cleaner",
-            "code_document_refiner",
-        ])
+        transformer = Transformer(
+            [
+                "rst_specific_node_cleaner",
+                "code_document_refiner",
+            ]
+        )
         transformed = transformer.transform(documents)
 
         self.assertEqual(len(transformed), len(expect_transformed_files))
@@ -425,7 +447,9 @@ class CodeDocumentRefinerTest(TransformerTestBase):
         expect_transformed_files = ["remove_trivial_nodes_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -434,10 +458,12 @@ class CodeDocumentRefinerTest(TransformerTestBase):
         for doc, expect in zip(documents, expect_files):
             self.compare_with_file_contents(doc.pformat(), expect)
 
-        transformer = Transformer([
-            "rst_specific_node_cleaner",
-            "code_document_refiner",
-        ])
+        transformer = Transformer(
+            [
+                "rst_specific_node_cleaner",
+                "code_document_refiner",
+            ]
+        )
         transformed = transformer.transform(documents)
 
         self.assertEqual(len(transformed), len(expect_transformed_files))
@@ -450,7 +476,9 @@ class CodeDocumentRefinerTest(TransformerTestBase):
         expect_transformed_files = ["remove_empty_nodes_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -459,10 +487,12 @@ class CodeDocumentRefinerTest(TransformerTestBase):
         for doc, expect in zip(documents, expect_files):
             self.compare_with_file_contents(doc.pformat(), expect)
 
-        transformer = Transformer([
-            "rst_specific_node_cleaner",
-            "code_document_refiner",
-        ])
+        transformer = Transformer(
+            [
+                "rst_specific_node_cleaner",
+                "code_document_refiner",
+            ]
+        )
         transformed = transformer.transform(documents)
 
         self.assertEqual(len(transformed), len(expect_transformed_files))
@@ -471,11 +501,11 @@ class CodeDocumentRefinerTest(TransformerTestBase):
 
 
 class DataTypeRefinerTest(TransformerTestBase):
-
     name = "DataTypeRefinerTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/data_type_refiner_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/data_type_refiner_test"
+    )
 
     def compare_with_file_contents(self, actual: str, expect_file: str):
         with open(expect_file, "r", encoding="utf-8") as f:
@@ -488,7 +518,9 @@ class DataTypeRefinerTest(TransformerTestBase):
         expect_transformed_files = ["basic_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -527,12 +559,15 @@ class DataTypeRefinerTest(TransformerTestBase):
         for doc, expect in zip(documents, expect_files):
             self.compare_with_file_contents(doc.pformat(), expect)
 
-        transformer = Transformer(["data_type_refiner"], {
-            "data_type_refiner": {
-                "package_structure": package_structure,
-                "entry_points": entry_points,
-            }
-        })
+        transformer = Transformer(
+            ["data_type_refiner"],
+            {
+                "data_type_refiner": {
+                    "package_structure": package_structure,
+                    "entry_points": entry_points,
+                }
+            },
+        )
         transformed = transformer.transform(documents)
 
         self.assertEqual(len(transformed), len(expect_transformed_files))
@@ -545,7 +580,9 @@ class DataTypeRefinerTest(TransformerTestBase):
         expect_transformed_files = ["various_data_type_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -574,11 +611,14 @@ class DataTypeRefinerTest(TransformerTestBase):
         for doc, expect in zip(documents, expect_files):
             self.compare_with_file_contents(doc.pformat(), expect)
 
-        transformer = Transformer(["data_type_refiner"], {
-            "data_type_refiner": {
-                "entry_points": entry_points,
-            }
-        })
+        transformer = Transformer(
+            ["data_type_refiner"],
+            {
+                "data_type_refiner": {
+                    "entry_points": entry_points,
+                }
+            },
+        )
         transformed = transformer.transform(documents)
 
         self.assertEqual(len(transformed), len(expect_transformed_files))
@@ -591,7 +631,9 @@ class DataTypeRefinerTest(TransformerTestBase):
         expect_transformed_files = ["special_data_type_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -606,11 +648,14 @@ class DataTypeRefinerTest(TransformerTestBase):
         for doc, expect in zip(documents, expect_files):
             self.compare_with_file_contents(doc.pformat(), expect)
 
-        transformer = Transformer(["data_type_refiner"], {
-            "data_type_refiner": {
-                "entry_points": entry_points,
-            }
-        })
+        transformer = Transformer(
+            ["data_type_refiner"],
+            {
+                "data_type_refiner": {
+                    "entry_points": entry_points,
+                }
+            },
+        )
         transformed = transformer.transform(documents)
 
         self.assertEqual(len(transformed), len(expect_transformed_files))
@@ -620,10 +665,15 @@ class DataTypeRefinerTest(TransformerTestBase):
     def test_option(self):
         rst_files = ["option_bpy.rst", "option_non_bpy.rst"]
         expect_files = ["option_bpy.xml", "option_non_bpy.xml"]
-        expect_transformed_files = ["option_bpy_transformed.xml", "option_non_bpy_transformed.xml"]
+        expect_transformed_files = [
+            "option_bpy_transformed.xml",
+            "option_non_bpy_transformed.xml",
+        ]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -645,7 +695,9 @@ class DataTypeRefinerTest(TransformerTestBase):
         expect_transformed_files = ["description_dependency_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -663,11 +715,11 @@ class DataTypeRefinerTest(TransformerTestBase):
 
 
 class DefaultValueFillerTest(TransformerTestBase):
-
     name = "DefaultValueFillerTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/default_value_filler_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/default_value_filler_test"
+    )
 
     def compare_with_file_contents(self, actual: str, expect_file: str):
         with open(expect_file, "r", encoding="utf-8") as f:
@@ -680,7 +732,9 @@ class DefaultValueFillerTest(TransformerTestBase):
         expect_transformed_files = ["basic_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -698,11 +752,11 @@ class DefaultValueFillerTest(TransformerTestBase):
 
 
 class DependencyBuilderTest(TransformerTestBase):
-
     name = "DependencyBuilderTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/dependency_builder_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/dependency_builder_test"
+    )
 
     def test_basic(self):
         rst_files = ["basic.rst"]
@@ -710,7 +764,9 @@ class DependencyBuilderTest(TransformerTestBase):
         expect_transformed_files = ["basic_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -738,11 +794,14 @@ class DependencyBuilderTest(TransformerTestBase):
         for doc, expect in zip(documents, expect_files):
             self.compare_with_file_contents(doc.pformat(), expect)
 
-        transformer = Transformer(["dependency_builder"], {
-            "dependency_builder": {
-                "package_structure": package_structure,
-            }
-        })
+        transformer = Transformer(
+            ["dependency_builder"],
+            {
+                "dependency_builder": {
+                    "package_structure": package_structure,
+                }
+            },
+        )
         transformed = transformer.transform(documents)
 
         self.assertEqual(len(transformed), len(expect_transformed_files))
@@ -751,11 +810,11 @@ class DependencyBuilderTest(TransformerTestBase):
 
 
 class FirstTitleRemoverTest(TransformerTestBase):
-
     name = "FirstTitleRemoverTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/first_title_remover_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/first_title_remover_test"
+    )
 
     def test_basic(self):
         rst_files = ["basic.rst"]
@@ -763,7 +822,9 @@ class FirstTitleRemoverTest(TransformerTestBase):
         expect_transformed_files = ["basic_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -772,9 +833,11 @@ class FirstTitleRemoverTest(TransformerTestBase):
         for doc, expect in zip(documents, expect_files):
             self.compare_with_file_contents(doc.pformat(), expect)
 
-        transformer = Transformer([
-            "first_title_remover",
-        ])
+        transformer = Transformer(
+            [
+                "first_title_remover",
+            ]
+        )
         transformed = transformer.transform(documents)
 
         self.assertEqual(len(transformed), len(expect_transformed_files))
@@ -787,7 +850,9 @@ class FirstTitleRemoverTest(TransformerTestBase):
         expect_transformed_files = ["multiple_titles_transformed.xml"]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -796,9 +861,11 @@ class FirstTitleRemoverTest(TransformerTestBase):
         for doc, expect in zip(documents, expect_files):
             self.compare_with_file_contents(doc.pformat(), expect)
 
-        transformer = Transformer([
-            "first_title_remover",
-        ])
+        transformer = Transformer(
+            [
+                "first_title_remover",
+            ]
+        )
         transformed = transformer.transform(documents)
 
         self.assertEqual(len(transformed), len(expect_transformed_files))
@@ -807,11 +874,11 @@ class FirstTitleRemoverTest(TransformerTestBase):
 
 
 class ModApplierTest(TransformerTestBase):
-
     name = "ModApplierTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/mod_applier_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/mod_applier_test"
+    )
 
     def test_new_data(self):
         rst_files = ["base.rst"]
@@ -826,7 +893,9 @@ class ModApplierTest(TransformerTestBase):
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
 
-        transformer = Transformer(["mod_applier"], {"mod_applier": {"mod_files": mod_files}})
+        transformer = Transformer(
+            ["mod_applier"], {"mod_applier": {"mod_files": mod_files}}
+        )
         transformed = transformer.transform(documents)
         self.assertEqual(len(transformer.get_transformers()), 1)
         mod_documents = transformer.get_transformers()[0].get_mod_documents()
@@ -852,7 +921,9 @@ class ModApplierTest(TransformerTestBase):
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
 
-        transformer = Transformer(["mod_applier"], {"mod_applier": {"mod_files": mod_files}})
+        transformer = Transformer(
+            ["mod_applier"], {"mod_applier": {"mod_files": mod_files}}
+        )
         transformed = transformer.transform(documents)
         self.assertEqual(len(transformer.get_transformers()), 1)
         mod_documents = transformer.get_transformers()[0].get_mod_documents()
@@ -878,7 +949,9 @@ class ModApplierTest(TransformerTestBase):
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
 
-        transformer = Transformer(["mod_applier"], {"mod_applier": {"mod_files": mod_files}})
+        transformer = Transformer(
+            ["mod_applier"], {"mod_applier": {"mod_files": mod_files}}
+        )
         transformed = transformer.transform(documents)
         self.assertEqual(len(transformer.get_transformers()), 1)
         mod_documents = transformer.get_transformers()[0].get_mod_documents()
@@ -904,7 +977,9 @@ class ModApplierTest(TransformerTestBase):
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
 
-        transformer = Transformer(["mod_applier"], {"mod_applier": {"mod_files": mod_files}})
+        transformer = Transformer(
+            ["mod_applier"], {"mod_applier": {"mod_files": mod_files}}
+        )
         transformed = transformer.transform(documents)
         self.assertEqual(len(transformer.get_transformers()), 1)
         mod_documents = transformer.get_transformers()[0].get_mod_documents()
@@ -930,7 +1005,9 @@ class ModApplierTest(TransformerTestBase):
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
 
-        transformer = Transformer(["mod_applier"], {"mod_applier": {"mod_files": mod_files}})
+        transformer = Transformer(
+            ["mod_applier"], {"mod_applier": {"mod_files": mod_files}}
+        )
         transformed = transformer.transform(documents)
         self.assertEqual(len(transformer.get_transformers()), 1)
         mod_documents = transformer.get_transformers()[0].get_mod_documents()
@@ -956,7 +1033,9 @@ class ModApplierTest(TransformerTestBase):
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
 
-        transformer = Transformer(["mod_applier"], {"mod_applier": {"mod_files": mod_files}})
+        transformer = Transformer(
+            ["mod_applier"], {"mod_applier": {"mod_files": mod_files}}
+        )
         transformed = transformer.transform(documents)
         self.assertEqual(len(transformer.get_transformers()), 1)
         mod_documents = transformer.get_transformers()[0].get_mod_documents()
@@ -982,7 +1061,9 @@ class ModApplierTest(TransformerTestBase):
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
 
-        transformer = Transformer(["mod_applier"], {"mod_applier": {"mod_files": mod_files}})
+        transformer = Transformer(
+            ["mod_applier"], {"mod_applier": {"mod_files": mod_files}}
+        )
         transformed = transformer.transform(documents)
         self.assertEqual(len(transformer.get_transformers()), 1)
         mod_documents = transformer.get_transformers()[0].get_mod_documents()
@@ -1008,7 +1089,9 @@ class ModApplierTest(TransformerTestBase):
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
 
-        transformer = Transformer(["mod_applier"], {"mod_applier": {"mod_files": mod_files}})
+        transformer = Transformer(
+            ["mod_applier"], {"mod_applier": {"mod_files": mod_files}}
+        )
         transformed = transformer.transform(documents)
         self.assertEqual(len(transformer.get_transformers()), 1)
         mod_documents = transformer.get_transformers()[0].get_mod_documents()
@@ -1027,7 +1110,9 @@ class ModApplierTest(TransformerTestBase):
         mod_files = [f"{self.data_dir}/input/{f}" for f in mod_files]
         expect_mod_files = [f"{self.data_dir}/expect/{f}" for f in expect_mod_files]
 
-        transformer = Transformer(["mod_applier"], {"mod_applier": {"mod_files": mod_files}})
+        transformer = Transformer(
+            ["mod_applier"], {"mod_applier": {"mod_files": mod_files}}
+        )
         _ = transformer.transform([])
         self.assertEqual(len(transformer.get_transformers()), 1)
         mod_documents = transformer.get_transformers()[0].get_mod_documents()
@@ -1038,11 +1123,11 @@ class ModApplierTest(TransformerTestBase):
 
 
 class SameModuleMergerTest(TransformerTestBase):
-
     name = "SameModuleMergerTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/same_module_merger_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/same_module_merger_test"
+    )
 
     def test_basic(self):
         rst_files = [
@@ -1061,7 +1146,9 @@ class SameModuleMergerTest(TransformerTestBase):
         ]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -1079,11 +1166,11 @@ class SameModuleMergerTest(TransformerTestBase):
 
 
 class TargetFileCombinerTest(TransformerTestBase):
-
     name = "TargetFileCombinerTest"
     module_name = __module__
     data_dir = os.path.abspath(
-        f"{os.path.dirname(__file__)}/transformer_test_data/target_file_combiner_test")
+        f"{os.path.dirname(__file__)}/transformer_test_data/target_file_combiner_test"
+    )
 
     def test_combine(self):
         rst_files = [
@@ -1102,7 +1189,9 @@ class TargetFileCombinerTest(TransformerTestBase):
         ]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -1133,7 +1222,9 @@ class TargetFileCombinerTest(TransformerTestBase):
         ]
         rst_files = [f"{self.data_dir}/input/{f}" for f in rst_files]
         expect_files = [f"{self.data_dir}/expect/{f}" for f in expect_files]
-        expect_transformed_files = [f"{self.data_dir}/expect/{f}" for f in expect_transformed_files]
+        expect_transformed_files = [
+            f"{self.data_dir}/expect/{f}" for f in expect_transformed_files
+        ]
 
         analyzer = BaseAnalyzer()
         documents = analyzer.analyze(rst_files)
@@ -1151,7 +1242,6 @@ class TargetFileCombinerTest(TransformerTestBase):
 
 
 class ModuleStructureTest(common.FakeBpyModuleTestBase):
-
     name = "ModuleStructureTest"
     module_name = __module__
 
@@ -1182,7 +1272,7 @@ class ModuleStructureTest(common.FakeBpyModuleTestBase):
                     "name": "module_1",
                     "module_1": [],
                 }
-            ]
+            ],
         }
 
         self.assertEqual(module_1.name, "module_1")
@@ -1219,8 +1309,8 @@ class ModuleStructureTest(common.FakeBpyModuleTestBase):
                             "children": [],
                         }
                     ],
-                }
-            ]
+                },
+            ],
         }
 
         self.assertEqual(module_1.name, "module_1")
@@ -1233,7 +1323,6 @@ class ModuleStructureTest(common.FakeBpyModuleTestBase):
 
 
 class UtilsTest(TransformerTestBase):
-
     name = "UtilsTest"
     module_name = __module__
 
@@ -1242,7 +1331,9 @@ class UtilsTest(TransformerTestBase):
         documents.append(publish_doctree(".. module:: module_1"))
         documents.append(publish_doctree(".. module:: module_1.submodule_1"))
         documents.append(publish_doctree(".. module:: module_1.submodule_2"))
-        documents.append(publish_doctree(".. module:: module_1.submodule_2.subsubmodule_1"))
+        documents.append(
+            publish_doctree(".. module:: module_1.submodule_2.subsubmodule_1")
+        )
 
         expect_dict = {
             "name": None,
@@ -1262,10 +1353,10 @@ class UtilsTest(TransformerTestBase):
                                     "children": [],
                                 }
                             ],
-                        }
-                    ]
+                        },
+                    ],
                 }
-            ]
+            ],
         }
 
         module_structure: ModuleStructure = build_module_structure(documents)
@@ -1298,6 +1389,7 @@ class UtilsTest(TransformerTestBase):
         self.assertIsNone(get_module_name(None, package))
         self.assertEqual(
             get_module_name("module_1.submodule_1.ClassA", package),
-            "module_1.submodule_1")
+            "module_1.submodule_1",
+        )
         self.assertIsNone(get_module_name("module_1.submodule_2.ClassA", package))
         self.assertEqual(get_module_name("module_1.ClassB", package), "module_1")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/utils_test.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/utils_test.py
@@ -2,12 +2,12 @@ import os
 from docutils import nodes
 from docutils.core import publish_doctree
 
-from fake_bpy_module.analyzer.nodes import (    # pylint: disable=E0401
+from fake_bpy_module.analyzer.nodes import (  # pylint: disable=E0401
     DataNode,
     NameNode,
     FunctionNode,
 )
-from fake_bpy_module.utils import (     # pylint: disable=E0401
+from fake_bpy_module.utils import (  # pylint: disable=E0401
     check_os,
     output_log,
     remove_unencodable,
@@ -25,7 +25,6 @@ from . import common
 
 
 class UtilsTest(common.FakeBpyModuleTestBase):
-
     name = "UtilsTest"
     module_name = __module__
 
@@ -96,7 +95,9 @@ class UtilsTest(common.FakeBpyModuleTestBase):
         func_node.element(NameNode).add_text("function_1")
         append_child(document, func_node)
 
-        self.assertEqual(document.pformat(), """<document source="<string>">
+        self.assertEqual(
+            document.pformat(),
+            """<document source="<string>">
     <module>
         <name>
             module.a
@@ -114,7 +115,8 @@ class UtilsTest(common.FakeBpyModuleTestBase):
         <return>
             <description>
             <data-type-list>
-""")
+""",
+        )
 
     def test_split_string_by_comma(self):
         sp = split_string_by_comma("a, b")

--- a/tests/python/fake_bpy_module_test/run_tests.py
+++ b/tests/python/fake_bpy_module_test/run_tests.py
@@ -12,8 +12,7 @@ class FakeBpyModuleTestConfig:
 def parse_options(config: FakeBpyModuleTestConfig):
     usage = f"Usage: python {__file__} [-p <modules_path>]"
     parser = argparse.ArgumentParser(usage)
-    parser.add_argument(
-        "-p", dest="modules_path", type=str, help="fake-module path")
+    parser.add_argument("-p", dest="modules_path", type=str, help="fake-module path")
 
     args = parser.parse_args()
     if args.modules_path:
@@ -28,11 +27,10 @@ def main():
     sys.path.append(path)
 
     sys.path.append(os.path.dirname(__file__))
-    import fake_bpy_module_test     # pylint: disable=C0415
+    import fake_bpy_module_test  # pylint: disable=C0415
 
     test_cases = [
         fake_bpy_module_test.analyzer_test.BaseAnalyzerTest,
-
         fake_bpy_module_test.generator_test.CodeWriterIndentTest,
         fake_bpy_module_test.generator_test.CodeWriterTest,
         fake_bpy_module_test.generator_test.SortedEntryPointNodesTest,
@@ -40,7 +38,6 @@ def main():
         fake_bpy_module_test.generator_test.PyInterfaceWriterTest,
         fake_bpy_module_test.generator_test.JsonWriterTest,
         fake_bpy_module_test.generator_test.CodeDocumentNodeTranslatorTest,
-
         fake_bpy_module_test.transformer_test.BaseClassFixtureTest,
         fake_bpy_module_test.transformer_test.BpyContextVariableConverterTest,
         fake_bpy_module_test.transformer_test.BpyModuleTweakerTest,
@@ -58,9 +55,7 @@ def main():
         fake_bpy_module_test.transformer_test.FirstTitleRemoverTest,
         fake_bpy_module_test.transformer_test.FormatValidatorTest,
         fake_bpy_module_test.transformer_test.UtilsTest,
-
         fake_bpy_module_test.integration_test.IntegrationTest,
-
         fake_bpy_module_test.utils_test.UtilsTest,
     ]
 

--- a/tests/python/import_module_test/run_tests.py
+++ b/tests/python/import_module_test/run_tests.py
@@ -23,7 +23,8 @@ def parse_options(config: ImportModuleTestConfig):
     usage = f"Usage: python {__file__} [-p <modules_path>]"
     parser = argparse.ArgumentParser(usage)
     parser.add_argument(
-        "-p", dest="modules_path", type=str, help="fake-bpy-module path")
+        "-p", dest="modules_path", type=str, help="fake-bpy-module path"
+    )
 
     args = parser.parse_args()
     if args.modules_path:
@@ -43,38 +44,37 @@ def generate_tests(config: ImportModuleTestConfig) -> list:
 
     # Load template.
     script_dir = os.path.dirname(__file__)
-    with open(f"{script_dir}/{TESTS_TEMPLATE_FILE}", "r",
-              encoding="utf-8") as f:
+    with open(f"{script_dir}/{TESTS_TEMPLATE_FILE}", "r", encoding="utf-8") as f:
         template_content = f.readlines()
 
     # Generate test codes.
     tests_dir = f"{script_dir}/{GENERATED_TESTS_DIR}"
     os.makedirs(tests_dir, exist_ok=False)
-    init_file = open(f"{tests_dir}/__init__.py", "w",   # pylint: disable=R1732
-                     encoding="utf-8")
+    init_file = open(  # pylint: disable=R1732
+        f"{tests_dir}/__init__.py",
+        "w",
+        encoding="utf-8",
+    )
 
-    def replace_template_content(
-            content: List[str], module_name: str) -> List[str]:
+    def replace_template_content(content: List[str], module_name: str) -> List[str]:
         output = []
         for line in content:
             line = re.sub(
                 r"<%% CLASS_NAME %%>",
                 "{}ImportTest".format(  # pylint: disable=C0209
                     re.sub(
-                        r"_(.)",
-                        lambda x: x.group(1).upper(),
-                        module_name.capitalize()
+                        r"_(.)", lambda x: x.group(1).upper(), module_name.capitalize()
                     )
                 ),
-                line)
+                line,
+            )
             line = re.sub(r"<%% MODULE_NAME %%>", module_name, line)
             output.append(line)
         return output
 
     for mod_name in module_names:
         test_codes = replace_template_content(template_content, mod_name)
-        with open(f"{tests_dir}/{mod_name}_test.py", "w",
-                  encoding="utf-8") as f:
+        with open(f"{tests_dir}/{mod_name}_test.py", "w", encoding="utf-8") as f:
             f.writelines(test_codes)
         init_file.write(f"from . import {mod_name}_test\n")
     init_file.close()
@@ -88,13 +88,11 @@ def generate_tests(config: ImportModuleTestConfig) -> list:
     # Get test cases.
     generated_tests_package = sys.modules[GENERATED_TESTS_DIR]
     tests_modules = [
-        m[1]
-        for m in inspect.getmembers(generated_tests_package, inspect.ismodule)]
+        m[1] for m in inspect.getmembers(generated_tests_package, inspect.ismodule)
+    ]
     test_cases = []
     for m in tests_modules:
-        test_cases.extend([
-            m[1]
-            for m in inspect.getmembers(m, inspect.isclass)])
+        test_cases.extend([m[1] for m in inspect.getmembers(m, inspect.isclass)])
 
     # Delete generated test codes.
     shutil.rmtree(tests_dir)


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

- Format code with Ruff (c.f. #171)

### Description about the pull request

- Add ruff format check in CI
- Add ruff config in pyproject.toml (line-length of 88, with Python 3.8 minimal version).
- Add `# fmt: skip` where we want to keep manual formatting (e.g. Blender version)
- Upgrade Ruff to the 0.4.4 version

