### PR TITLE
Fix typing.Tuple syntax reintroduced in mod file

### DIFF
--- a/src/mods/common/analyzer/update/bpy.app.mod.rst
+++ b/src/mods/common/analyzer/update/bpy.app.mod.rst
@@ -4,7 +4,7 @@
 
 .. data:: version
 
-   :type: typing.Tuple[int, int, int]
+   :type: tuple[int, int, int]
    :mod-option: skip-refine
 
 .. data:: binary_path


### PR DESCRIPTION
327a3c4eb313c7b2a9ae35f8dce762e81c3f9a67 reintroduced `typing.Tuple` syntax into a mod file, a regression on #161.
https://github.com/nutti/fake-bpy-module/blob/327a3c4eb313c7b2a9ae35f8dce762e81c3f9a67/src/mods/common/analyzer/update/bpy.app.mod.rst?plain=1#L7

This PR has no conflicts with #221.