### PR TITLE
Replace deprecated aliases to ABCs in collections.abc

### DIFF
--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -220,7 +220,7 @@ class DataTypeRefiner(TransformerBase):
         if dtype_str == "bytes":
             return [make_data_type_node("bytes")]
         if dtype_str.startswith("byte sequence"):
-            return [make_data_type_node("typing.Sequence[bytes]")]
+            return [make_data_type_node("collections.abc.Sequence[bytes]")]
 
         if dtype_str.lower().startswith("callable"):
             return [make_data_type_node("typing.Callable")]
@@ -231,7 +231,7 @@ class DataTypeRefiner(TransformerBase):
                     m.group(1), uniq_full_names, uniq_module_names,
                     module_name)
                 if s:
-                    return [make_data_type_node("typing.Sequence[float]"),
+                    return [make_data_type_node("collections.abc.Sequence[float]"),
                             make_data_type_node(f"`{s}`")]
 
         # Ex: int array of 2 items in [-32768, 32767], default (0, 0)
@@ -261,7 +261,7 @@ class DataTypeRefiner(TransformerBase):
                 module_name)
             if s:
                 return [
-                    make_data_type_node("typing.Sequence[float]"),
+                    make_data_type_node("collections.abc.Sequence[float]"),
                     make_data_type_node(f"`{s}`")
                 ]
         # Ex: int in [-inf, inf], default 0, (readonly)
@@ -272,7 +272,7 @@ class DataTypeRefiner(TransformerBase):
         if dtype_str in ("unsigned int", "int (boolean)"):
             return [make_data_type_node("int")]
         if dtype_str == "int sequence":
-            return [make_data_type_node("typing.Sequence[int]")]
+            return [make_data_type_node("collections.abc.Sequence[int]")]
 
         # Ex: float multi-dimensional array of 3 * 3 items in [-inf, inf]
         if m := REGEX_MATCH_DATA_TYPE_FLOAT_MULTI_DIMENSIONAL_ARRAY_OF.match(dtype_str):  # noqa # pylint: disable=C0301
@@ -310,7 +310,7 @@ class DataTypeRefiner(TransformerBase):
         if dtype_str == "tuple":
             return [make_data_type_node("tuple")]
         if dtype_str == "sequence":
-            return [make_data_type_node("typing.Sequence")]
+            return [make_data_type_node("collections.abc.Sequence")]
 
         if dtype_str.startswith("`bgl.Buffer` "):
             s1 = self._parse_custom_data_type(

--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -238,7 +238,7 @@ class DataTypeRefiner(TransformerBase):
         if m := REGEX_MATCH_DATA_TYPE_NUMBER_ARRAY_OF.match(dtype_str):
             if m.group(1) in ("int", "float"):
                 if variable_kind == 'FUNC_ARG':
-                    return [make_data_type_node(f"typing.Iterable[{m.group(1)}]")]
+                    return [make_data_type_node(f"collections.abc.Iterable[{m.group(1)}]")]
                 return [make_data_type_node(f"`bpy.types.bpy_prop_array`[{m.group(1)}]")]
         # Ex: :`mathutils.Euler` rotation of 3 items in [-inf, inf],
         #     default (0.0, 0.0, 0.0)
@@ -336,7 +336,7 @@ class DataTypeRefiner(TransformerBase):
         #   Pattern: sequence of string tuples or a function
         if dtype_str == "sequence of string tuples or a function":
             return [
-                make_data_type_node("typing.Iterable[typing.Iterable[str]]"),
+                make_data_type_node("collections.abc.Iterable[collections.abc.Iterable[str]]"),
                 make_data_type_node("typing.Callable")
             ]
         # Ex: sequence of bpy.types.Action
@@ -344,7 +344,7 @@ class DataTypeRefiner(TransformerBase):
             s = self._parse_custom_data_type(
                 m.group(1), uniq_full_names, uniq_module_names, module_name)
             if s:
-                return [make_data_type_node(f"typing.Iterable[`{s}`]")]
+                return [make_data_type_node(f"collections.abc.Iterable[`{s}`]")]
         # Ex: `bpy_prop_collection` of `ThemeStripColor`,
         #     (readonly, never None)
         if m := REGEX_MATCH_DATA_TYPE_BPY_PROP_COLLECTION_OF.match(dtype_str):

--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -148,7 +148,7 @@ class DataTypeRefiner(TransformerBase):
                 module_name)
             if s:
                 return [
-                    make_data_type_node("list[typing.Callable[[`bpy.types.Scene`, None]]]")
+                    make_data_type_node("list[collections.abc.Callable[[`bpy.types.Scene`, None]]]")
                 ]
 
         if dtype_str == "Same type with self class":
@@ -223,7 +223,7 @@ class DataTypeRefiner(TransformerBase):
             return [make_data_type_node("collections.abc.Sequence[bytes]")]
 
         if dtype_str.lower().startswith("callable"):
-            return [make_data_type_node("typing.Callable")]
+            return [make_data_type_node("collections.abc.Callable")]
 
         if m := REGEX_MATCH_DATA_TYPE_MATHUTILS_VALUES.match(dtype_str):
             if variable_kind in ('FUNC_ARG', 'CONST', 'CLS_ATTR'):
@@ -337,7 +337,7 @@ class DataTypeRefiner(TransformerBase):
         if dtype_str == "sequence of string tuples or a function":
             return [
                 make_data_type_node("collections.abc.Iterable[collections.abc.Iterable[str]]"),
-                make_data_type_node("typing.Callable")
+                make_data_type_node("collections.abc.Callable")
             ]
         # Ex: sequence of bpy.types.Action
         if m := REGEX_MATCH_DATA_TYPE_SEQUENCE_OF.match(dtype_str):

--- a/src/fake_bpy_module/transformer/default_value_filler.py
+++ b/src/fake_bpy_module/transformer/default_value_filler.py
@@ -64,7 +64,7 @@ class DefaultValueFiller(TransformerBase):
                         "typing.Iterator": "[]",
                         "typing.Callable": "None",
                         "typing.Any": "None",
-                        "typing.Sequence": "[]",
+                        "collections.abc.Sequence": "[]",
                     }
                     found_type = False
                     for mod_dtype, default_value in MODIFIER_DTYPE_DEFAULT_VALUE_MAP.items():

--- a/src/fake_bpy_module/transformer/default_value_filler.py
+++ b/src/fake_bpy_module/transformer/default_value_filler.py
@@ -61,7 +61,7 @@ class DefaultValueFiller(TransformerBase):
                         "set": "()",
                         "tuple": "()",
                         "Generic": "None",
-                        "typing.Iterator": "[]",
+                        "collections.abc.Iterator": "[]",
                         "typing.Callable": "None",
                         "typing.Any": "None",
                         "collections.abc.Sequence": "[]",

--- a/src/fake_bpy_module/transformer/default_value_filler.py
+++ b/src/fake_bpy_module/transformer/default_value_filler.py
@@ -62,7 +62,7 @@ class DefaultValueFiller(TransformerBase):
                         "tuple": "()",
                         "Generic": "None",
                         "collections.abc.Iterator": "[]",
-                        "typing.Callable": "None",
+                        "collections.abc.Callable": "None",
                         "typing.Any": "None",
                         "collections.abc.Sequence": "[]",
                     }

--- a/src/mods/common/analyzer/append/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/append/bpy.types.mod.rst
@@ -55,7 +55,7 @@
 
    .. method:: __iter__()
 
-      :rtype: typing.Iterator[GenericType1]
+      :rtype: collections.abc.Iterator[GenericType1]
       :mod-option rtype: skip-refine
 
    .. method:: __next__()

--- a/src/mods/common/analyzer/new/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/new/bpy.types.mod.rst
@@ -39,7 +39,7 @@
 
    .. method:: __iter__()
 
-      :rtype: typing.Iterator[GenericType1]
+      :rtype: collections.abc.Iterator[GenericType1]
       :mod-option rtype: skip-refine
 
    .. method:: __next__()

--- a/src/mods/common/analyzer/update/bpy.app.timers.mod.rst
+++ b/src/mods/common/analyzer/update/bpy.app.timers.mod.rst
@@ -5,17 +5,17 @@
 .. function:: is_registered(function)
 
    :arg function: Function to check.
-   :type function: typing.Callable[[], float]
+   :type function: collections.abc.Callable[[], float]
    :mod-option arg function: skip-refine
 
 .. function:: register(function)
 
    :arg function: The function that should called.
-   :type function: typing.Callable[[], float]
+   :type function: collections.abc.Callable[[], float]
    :mod-option arg function: skip-refine
 
 .. function:: unregister(function)
 
    :arg function: Function to unregister.
-   :type function: typing.Callable[[], float]
+   :type function: collections.abc.Callable[[], float]
    :mod-option arg function: skip-refine

--- a/src/mods/common/analyzer/update/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/update/bpy.types.mod.rst
@@ -34,5 +34,5 @@
 
       :type attr: str
       :mod-option arg attr: skip-refine
-      :type seq: typing.Sequence[bool] | typing.Sequence[int] | typing.Sequence[float]
+      :type seq: collections.abc.Sequence[bool] | collections.abc.Sequence[int] | collections.abc.Sequence[float]
       :mod-option arg seq: skip-refine

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
@@ -225,7 +225,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="never none">
-                        typing.Iterable[float]
+                        collections.abc.Iterable[float]
         <return>
             <description>
             <data-type-list>
@@ -385,7 +385,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Iterable[typing.Iterable[str]]
+                collections.abc.Iterable[collections.abc.Iterable[str]]
             <data-type option="never none">
                 typing.Callable
     <data>
@@ -394,7 +394,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Iterable[
+                collections.abc.Iterable[
                 <class-ref>
                     refined_module_a.RefinedClassA
                 ]

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
@@ -186,7 +186,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Sequence[bytes]
+                collections.abc.Sequence[bytes]
     <data>
         <name>
             data_callable
@@ -200,7 +200,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Sequence[float]
+                collections.abc.Sequence[float]
             <data-type option="never none">
                 <class-ref>
                     mathutils.Vector
@@ -247,7 +247,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Sequence[float]
+                collections.abc.Sequence[float]
             <data-type option="never none">
                 <class-ref>
                     mathutils.Vector
@@ -292,7 +292,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Sequence[int]
+                collections.abc.Sequence[int]
     <data>
         <name>
             data_float_multi_dimensional_array_of
@@ -355,7 +355,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Sequence
+                collections.abc.Sequence
     <data>
         <name>
             data_bgl_buffer

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
@@ -18,7 +18,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                list[typing.Callable[[
+                list[collections.abc.Callable[[
                 <class-ref>
                     bpy.types.Scene
                 , None]]]
@@ -193,7 +193,7 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                typing.Callable
+                collections.abc.Callable
     <data>
         <name>
             data_mathutils_values
@@ -387,7 +387,7 @@
             <data-type option="never none">
                 collections.abc.Iterable[collections.abc.Iterable[str]]
             <data-type option="never none">
-                typing.Callable
+                collections.abc.Callable
     <data>
         <name>
             data_sequence_of

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic.xml
@@ -145,7 +145,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Callable
+                        collections.abc.Callable
             <argument argument_type="arg">
                 <name>
                     arg_any

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic.xml
@@ -137,7 +137,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Iterator
+                        collections.abc.Iterator
             <argument argument_type="arg">
                 <name>
                     arg_callable

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic.xml
@@ -161,7 +161,7 @@
                 <default-value>
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Sequence[int]
+                        collections.abc.Sequence[int]
         <return>
             <description>
             <data-type-list>

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic_transformed.xml
@@ -161,7 +161,7 @@
                     None
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Callable
+                        collections.abc.Callable
             <argument argument_type="arg">
                 <name>
                     arg_any

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic_transformed.xml
@@ -152,7 +152,7 @@
                     []
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Iterator
+                        collections.abc.Iterator
             <argument argument_type="arg">
                 <name>
                     arg_callable

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/expect/basic_transformed.xml
@@ -179,7 +179,7 @@
                     []
                 <data-type-list>
                     <data-type option="optional">
-                        typing.Sequence[int]
+                        collections.abc.Sequence[int]
         <return>
             <description>
             <data-type-list>

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/input/basic.rst
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/input/basic.rst
@@ -34,7 +34,7 @@
    :option arg arg_tuple: optional
    :type arg_generic: Generic[Type]
    :option arg arg_generic: optional
-   :type arg_iterator: typing.Iterator
+   :type arg_iterator: collections.abc.Iterator
    :option arg arg_iterator: optional
    :type arg_callable: typing.Callable
    :option arg arg_callable: optional

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/input/basic.rst
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/input/basic.rst
@@ -40,5 +40,5 @@
    :option arg arg_callable: optional
    :type arg_any: typing.Any
    :option arg arg_any: optional
-   :type arg_sequence: typing.Sequence[int]
+   :type arg_sequence: collections.abc.Sequence[int]
    :option arg arg_sequence: optional

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/input/basic.rst
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/default_value_filler_test/input/basic.rst
@@ -36,7 +36,7 @@
    :option arg arg_generic: optional
    :type arg_iterator: collections.abc.Iterator
    :option arg arg_iterator: optional
-   :type arg_callable: typing.Callable
+   :type arg_callable: collections.abc.Callable
    :option arg arg_callable: optional
    :type arg_any: typing.Any
    :option arg arg_any: optional


### PR DESCRIPTION
A continuation of the work towards resolving #161 that was started in #207—`typing.Sequence`, `typing.Iterable`, `typing.Iterator` and `typing.Callable` are all deprecated aliases to types of the same name in `collections.abc`.

I'm certainly not familiar with the codebase yet, so I'm submitting this now for checks and review even though it conflicts with #221.