### PR TITLE
Fix: Use | None instead of typing.Optional

### DIFF
--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -279,7 +279,7 @@ class PyCodeWriterBase(BaseWriter):
                         if "option" not in dtype_node.attributes:
                             continue
                         if "accept none" in dtype_node.attributes["option"]:
-                            dtype_str = f"typing.Optional[{dtype_str}]"
+                            dtype_str = f"{dtype_str} | None"
                             break
 
                 if dtype_str is not None:
@@ -449,7 +449,7 @@ class PyCodeWriterBase(BaseWriter):
                 if "option" not in dtype_node.attributes:
                     continue
                 if "accept none" in dtype_node.attributes["option"]:
-                    dtype = f"typing.Optional[{dtype}]"
+                    dtype = f"{dtype} | None"
                     break
             wt.addln(f"{name_node.astext()}: {dtype}"
                      f"{self.ellipsis_strings['constant']}")


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

- Fix regression of #161 with `typing.Optional`.
