### PR TITLE
Fix bpy_prop_collection.items missing return type

### DIFF
--- a/src/mods/common/analyzer/update/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/update/bpy.types.mod.rst
@@ -21,7 +21,7 @@
    .. method:: items()
 
       :rtype: list[tuple[str, GenericType1]]
-      :mod-option return: skip-refine
+      :mod-option rtype: skip-refine
 
    .. method:: foreach_get(attr, seq)
 


### PR DESCRIPTION
`bpy_prop_collection.items()`'s return type was being refined away due to a typo in e0e70e19630a511340dd298e24b30a1ea67e435d.