### PR TITLE
Fix BMesh typing (#179)

### DIFF
--- a/src/mods/common/analyzer/append/bmesh.types.mod.rst
+++ b/src/mods/common/analyzer/append/bmesh.types.mod.rst
@@ -4,21 +4,11 @@
 
 .. class:: BMElemSeq
 
+   .. base-class:: typing.Generic[GenericType1]
+
+      :mod-option base-class: skip-refine
+
    .. method:: __getitem__(key)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :rtype: GenericType1
-      :mod-option rtype: skip-refine
-
-   .. method:: __setitem__(key, value)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :type value: GenericType1
-      :mod-option arg value: skip-refine
-
-   .. method:: __delitem__(key)
 
       :type key: int
       :mod-option arg key: skip-refine
@@ -27,12 +17,7 @@
 
    .. method:: __iter__()
 
-      :rtype: typing.Iterator[GenericType1]
-      :mod-option rtype: skip-refine
-
-   .. method:: __next__()
-
-      :rtype: GenericType1
+      :rtype: BMIter[GenericType1]
       :mod-option rtype: skip-refine
 
    .. method:: __len__()
@@ -48,26 +33,9 @@
       :mod-option arg key: skip-refine
       :rtype: :class:`BMVert`
 
-   .. method:: __setitem__(key, value)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :type value: :class:`BMVert`
-
-   .. method:: __delitem__(key)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :rtype: :class:`BMVert`
-
    .. method:: __iter__()
 
-      :rtype: typing.Iterator[GenericType1]
-      :mod-option rtype: skip-refine
-
-   .. method:: __next__()
-
-      :rtype: GenericType1
+      :rtype: BMIter[BMVert]
       :mod-option rtype: skip-refine
 
    .. method:: __len__()
@@ -83,61 +51,9 @@
       :mod-option arg key: skip-refine
       :rtype: :class:`BMEdge`
 
-   .. method:: __setitem__(key, value)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :type value: :class:`BMEdge`
-
-   .. method:: __delitem__(key)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :rtype: :class:`BMEdge`
-
    .. method:: __iter__()
 
-      :rtype: typing.Iterator[GenericType1]
-      :mod-option rtype: skip-refine
-
-   .. method:: __next__()
-
-      :rtype: GenericType1
-      :mod-option rtype: skip-refine
-
-   .. method:: __len__()
-
-      :rtype: int
-      :mod-option rtype: skip-refine
-
-.. class:: BMLoopSeq
-
-   .. method:: __getitem__(key)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :rtype: :class:`BMLoop`
-
-   .. method:: __setitem__(key, value)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :type value: :class:`BMLoop`
-
-   .. method:: __delitem__(key)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :rtype: :class:`BMLoop`
-
-   .. method:: __iter__()
-
-      :rtype: typing.Iterator[GenericType1]
-      :mod-option rtype: skip-refine
-
-   .. method:: __next__()
-
-      :rtype: GenericType1
+      :rtype: BMIter[BMEdge]
       :mod-option rtype: skip-refine
 
    .. method:: __len__()
@@ -153,26 +69,9 @@
       :mod-option arg key: skip-refine
       :rtype: :class:`BMFace`
 
-   .. method:: __setitem__(key, value)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :type value: :class:`BMFace`
-
-   .. method:: __delitem__(key)
-
-      :type key: int
-      :mod-option arg key: skip-refine
-      :rtype: :class:`BMFace`
-
    .. method:: __iter__()
 
-      :rtype: typing.Iterator[GenericType1]
-      :mod-option rtype: skip-refine
-
-   .. method:: __next__()
-
-      :rtype: GenericType1
+      :rtype: BMIter[BMFace]
       :mod-option rtype: skip-refine
 
    .. method:: __len__()
@@ -180,3 +79,18 @@
       :rtype: int
       :mod-option rtype: skip-refine
 
+.. class:: BMIter
+
+   .. base-class:: typing.Generic[GenericType1]
+
+      :mod-option base-class: skip-refine
+
+   .. method:: __iter__()
+
+      :rtype: BMIter[GenericType1]
+      :mod-option rtype: skip-refine
+
+   .. method:: __next__()
+
+      :rtype: GenericType1
+      :mod-option rtype: skip-refine

--- a/src/mods/common/analyzer/append/bmesh.types.mod.rst
+++ b/src/mods/common/analyzer/append/bmesh.types.mod.rst
@@ -101,3 +101,87 @@
 
       :rtype: BMLayerItem | GenericType2
       :mod-option rtype: skip-refine
+
+.. class:: BMVert
+
+   .. method:: __getitem__(key)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+      :rtype: typing.Any
+      :mod-option rtype: skip-refine
+
+   .. method:: __setitem__(key, value)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+      :type value: typing.Any
+      :mod-option arg value: skip-refine
+
+   .. method:: __delitem__(key)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+
+.. class:: BMEdge
+
+   .. method:: __getitem__(key)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+      :rtype: typing.Any
+      :mod-option rtype: skip-refine
+
+   .. method:: __setitem__(key, value)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+      :type value: typing.Any
+      :mod-option arg value: skip-refine
+
+   .. method:: __delitem__(key)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+
+.. class:: BMFace
+
+   .. method:: __getitem__(key)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+      :rtype: typing.Any
+      :mod-option rtype: skip-refine
+
+   .. method:: __setitem__(key, value)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+      :type value: typing.Any
+      :mod-option arg value: skip-refine
+
+   .. method:: __delitem__(key)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+
+.. class:: BMLoop
+
+   .. method:: __getitem__(key)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+      :rtype: typing.Any
+      :mod-option rtype: skip-refine
+
+   .. method:: __setitem__(key, value)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine
+      :type value: typing.Any
+      :mod-option arg value: skip-refine
+
+   .. method:: __delitem__(key)
+
+      :type key: BMLayerItem
+      :mod-option arg key: skip-refine

--- a/src/mods/common/analyzer/append/bmesh.types.mod.rst
+++ b/src/mods/common/analyzer/append/bmesh.types.mod.rst
@@ -94,3 +94,10 @@
 
       :rtype: GenericType1
       :mod-option rtype: skip-refine
+
+.. class:: BMLayerCollection
+
+   .. method:: get()
+
+      :rtype: BMLayerItem | GenericType2
+      :mod-option rtype: skip-refine

--- a/src/mods/common/analyzer/update/bmesh.types.mod.rst
+++ b/src/mods/common/analyzer/update/bmesh.types.mod.rst
@@ -12,3 +12,27 @@
          *key* is not found.
       :type default: GenericType2
       :mod-option arg default: skip-refine
+
+.. class:: BMVert
+
+   .. method:: copy_from(other)
+
+      :type other: `BMVert`
+
+.. class:: BMEdge
+
+   .. method:: copy_from(other)
+
+      :type other: `BMEdge`
+
+.. class:: BMFace
+
+   .. method:: copy_from(other)
+
+      :type other: `BMFace`
+
+.. class:: BMLoop
+
+   .. method:: copy_from(other)
+
+      :type other: `BMLoop`

--- a/src/mods/common/analyzer/update/bmesh.types.mod.rst
+++ b/src/mods/common/analyzer/update/bmesh.types.mod.rst
@@ -1,0 +1,14 @@
+.. mod-type:: update
+
+.. module:: bmesh.types
+
+.. class:: BMLayerCollection
+
+   .. method:: get(key, default=None)
+
+      :arg key: The key associated with the layer.
+      :type key: string
+      :arg default: Optional argument for the value to return if
+         *key* is not found.
+      :type default: GenericType2
+      :mod-option arg default: skip-refine


### PR DESCRIPTION
- BMesh sequences were missing generic base class, so generic arguments and return values were not changing with subscription.
- Additionally BMesh sequences were being given methods they don't have, and `BMIter` was not being used as iterable return type.
- `BMLayerCollection`'s `get()` method now has a return type.
- Added `__getitem__()`, `__setitem__()` and `__delitem__()` to `BMVert`, `BMEdge`, `BMLoop` and `BMFace`.*

Fixes #179

*Presently these methods get/set `Any`—to fix this `BMLayerItem` needs to be made generic (trivial), but that generic type needs to come from `BMLayerCollection` which also needs to be made generic, which involves modding all of its methods and uses (non-trivial), and I don't think it's currently possible to bind that generic type to `BMLayerItem` (but it might be after #161's work on PEP 695 is implemented?).