### PR TITLE
fix building instructions

### DIFF
--- a/docs/generate_modules.md
+++ b/docs/generate_modules.md
@@ -164,11 +164,11 @@ Or, you can download .zip file from GitHub.
 cd fake-bpy-module/src
 
 mkdir -p mods/generated_mods
-${BLENDER_BIN}/blender --background --factory-startup -noaudio --python-exit-code 1 --python gen_modfile/gen_external_modules_modfile.py -- -m addon_utils -o mods/generated_mods/gen_modules_modfile
-${BLENDER_BIN}/blender --background --factory-startup -noaudio --python-exit-code 1 --python gen_modfile/gen_external_modules_modfile.py -- -m keyingsets_builtins -a -o mods/generated_mods/gen_startup_modfile
+${BLENDER_BIN}/blender --background --factory-startup -noaudio --python-exit-code 1 --python gen_modfile/gen_external_modules_modfile.py -- -m addon_utils -o mods/generated_mods/gen_modules_modfile -f json
+${BLENDER_BIN}/blender --background --factory-startup -noaudio --python-exit-code 1 --python gen_modfile/gen_external_modules_modfile.py -- -m keyingsets_builtins -a -o mods/generated_mods/gen_startup_modfile -f json
 
 mkdir -p mods/generated_mods/gen_bgl_modfile
-python gen_modfile/gen_bgl_modfile.py -i ${BLENDER_SRC}/source/blender/python/generic/bgl.c -o mods/generated_mods/gen_bgl_modfile/bgl.json
+python gen_modfile/gen_bgl_modfile.py -i ${BLENDER_SRC}/source/blender/python/generic/bgl.c -o mods/generated_mods/gen_bgl_modfile/bgl.json -f json
 ```
 <!-- markdownlint-enable MD013 -->
 

--- a/docs/generate_modules.md
+++ b/docs/generate_modules.md
@@ -168,7 +168,7 @@ ${BLENDER_BIN}/blender --background --factory-startup -noaudio --python-exit-cod
 ${BLENDER_BIN}/blender --background --factory-startup -noaudio --python-exit-code 1 --python gen_modfile/gen_external_modules_modfile.py -- -m keyingsets_builtins -a -o mods/generated_mods/gen_startup_modfile -f json
 
 mkdir -p mods/generated_mods/gen_bgl_modfile
-python gen_modfile/gen_bgl_modfile.py -i ${BLENDER_SRC}/source/blender/python/generic/bgl.c -o mods/generated_mods/gen_bgl_modfile/bgl.json -f json
+python gen_modfile/gen_bgl_modfile.py -i ${BLENDER_SRC}/source/blender/python/generic/bgl.cc -o mods/generated_mods/gen_bgl_modfile/bgl.json -f json
 ```
 <!-- markdownlint-enable MD013 -->
 

--- a/src/gen_modfile/gen_bgl_modfile.py
+++ b/src/gen_modfile/gen_bgl_modfile.py
@@ -4,11 +4,11 @@
 #
 # Description:
 #   gen_bgl_modfile.py generates python constant and function definitions
-#   which are defined by bgl.c.
+#   which are defined by bgl.cc.
 #   The definitions are output as a modfile format.
 #
 # Note:
-#   You need to download blender source code for passing 'bgl.c' file to
+#   You need to download blender source code for passing 'bgl.cc' file to
 #   this script.
 #
 # Usage:
@@ -16,7 +16,7 @@
 #     -f <output_format>
 #
 #     bgl_c_file:
-#       Path to bgl.c.
+#       Path to bgl.cc.
 #
 #     output_file:
 #       Generated definitions are output to specified file.
@@ -191,7 +191,7 @@ def analyze(config: 'GenerationConfig') -> Dict:
 def parse_options() -> 'GenerationConfig':
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "-i", dest="bgl_c_file", type=str, help="Path to bgl.c",
+        "-i", dest="bgl_c_file", type=str, help="Path to bgl.cc",
         required=True
     )
     parser.add_argument(
@@ -250,7 +250,7 @@ def write_to_modfile(data: Dict, config: 'GenerationConfig'):
 def main():
     config = parse_options()
 
-    # Analyze bgl.c.
+    # Analyze bgl.cc.
     results = analyze(config)
 
     # Write definitions to file.


### PR DESCRIPTION
1) add non-optional `-f` flag
2) replace bgl.c with bgl.cc as bgl.c is currently deprecated