### PR TITLE
Update: Sort and deduplicate union elements

### DIFF
--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -96,6 +96,9 @@ def sorted_entry_point_nodes(document: nodes.document) -> List[NodeBase]:
 
     return sorted_nodes
 
+def make_union(dtype_nodes: List[DataTypeNode]) -> str:
+    return ' | '.join(sorted({n.to_string() for n in set(dtype_nodes)}))
+
 
 class BaseWriter(metaclass=abc.ABCMeta):
     def __init__(self):
@@ -147,10 +150,7 @@ class PyCodeWriterBase(BaseWriter):
 
             if not dtype_list_node.empty():
                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                if len(dtype_nodes) >= 2:
-                    dtype_str = ' | '.join(n.to_string() for n in dtype_nodes)
-                else:
-                    dtype_str = dtype_nodes[0].to_string()
+                dtype_str = make_union(dtype_nodes)
                 for dtype_node in dtype_nodes:
                     if "option" not in dtype_node.attributes:
                         continue
@@ -176,10 +176,7 @@ class PyCodeWriterBase(BaseWriter):
             dtype_list_node = return_node.element(DataTypeListNode)
             if not dtype_list_node.empty():
                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                if len(dtype_nodes) >= 2:
-                    dtype = ' | '.join(n.to_string() for n in dtype_nodes)
-                else:
-                    dtype = dtype_nodes[0].to_string()
+                dtype = make_union(dtype_nodes)
                 for dtype_node in dtype_nodes:
                     if "option" not in dtype_node.attributes:
                         continue
@@ -215,7 +212,7 @@ class PyCodeWriterBase(BaseWriter):
                         wt.addln(f":param {name_node.astext()}: {desc_node.astext()}")
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                        dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
+                        dtype_str = make_union(dtype_nodes)
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
@@ -230,7 +227,7 @@ class PyCodeWriterBase(BaseWriter):
                         wt.addln(f":return: {desc_node.astext()}")
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                        dtype = " | ".join(n.to_string() for n in dtype_nodes)
+                        dtype = make_union(dtype_nodes)
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
@@ -297,7 +294,7 @@ class PyCodeWriterBase(BaseWriter):
                 dtype_str = None
                 if not dtype_list_node.empty():
                     dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                    dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
+                    dtype_str = make_union(dtype_nodes)
                     for dtype_node in dtype_nodes:
                         if "option" not in dtype_node.attributes:
                             continue
@@ -373,7 +370,7 @@ class PyCodeWriterBase(BaseWriter):
 
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                        dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
+                        dtype_str = make_union(dtype_nodes)
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
@@ -403,7 +400,7 @@ class PyCodeWriterBase(BaseWriter):
                     dtype_list_node = return_node.element(DataTypeListNode)
                     if not dtype_list_node.empty():
                         dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                        dtype = " | ".join(n.to_string() for n in dtype_nodes)
+                        dtype = make_union(dtype_nodes)
                         for dtype_node in dtype_nodes:
                             if "option" not in dtype_node.attributes:
                                 continue
@@ -433,7 +430,7 @@ class PyCodeWriterBase(BaseWriter):
                             wt.addln(f":param {name_node.astext()}: {desc_node.astext()}")
                             if not dtype_list_node.empty():
                                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                                dtype_str = " | ".join(n.to_string() for n in dtype_nodes)
+                                dtype_str = make_union(dtype_nodes)
                                 for dtype_node in dtype_nodes:
                                     if "option" not in dtype_node.attributes:
                                         continue
@@ -450,7 +447,7 @@ class PyCodeWriterBase(BaseWriter):
 
                             if not dtype_list_node.empty():
                                 dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-                                dtype = " | ".join(n.to_string() for n in dtype_nodes)
+                                dtype = make_union(dtype_nodes)
                                 for dtype_node in dtype_nodes:
                                     if "option" not in dtype_node.attributes:
                                         continue
@@ -478,7 +475,7 @@ class PyCodeWriterBase(BaseWriter):
 
         if not dtype_list_node.empty():
             dtype_nodes = find_children(dtype_list_node, DataTypeNode)
-            dtype = " | ".join(n.to_string() for n in dtype_nodes)
+            dtype = make_union(dtype_nodes)
             for dtype_node in dtype_nodes:
                 if "option" not in dtype_node.attributes:
                     continue

--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -96,6 +96,7 @@ def sorted_entry_point_nodes(document: nodes.document) -> List[NodeBase]:
 
     return sorted_nodes
 
+
 def make_union(dtype_nodes: List[DataTypeNode]) -> str:
     return ' | '.join(sorted({n.to_string() for n in set(dtype_nodes)}))
 


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

Sometimes in union types there was duplicate element like `str | int | str` instead of `str | int`.
This PR now deduplicate union element and sort them to ensure reproducibility.
- Found this problem when working on #238

### Description of the pull request

I added the function `make_union` to avoid code duplication.