### PR TITLE
Update: Improve bpy_prop_array typing

### DIFF
--- a/src/mods/common/analyzer/new/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/new/bpy.types.mod.rst
@@ -8,6 +8,16 @@
 
       :mod-option base-class: skip-refine
 
+   .. method:: __get__(instance, owner)
+
+      :rtype: bpy_prop_array[GenericType1]
+      :mod-option rtype: skip-refine
+
+   .. method:: __set__(instance, value)
+
+      :type value: collections.abc.Iterable[GenericType1]
+      :mod-option arg value: skip-refine
+
    .. method:: foreach_get(seq)
 
       :type seq: collections.abc.MutableSequence[GenericType1]


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

- Fix #162 

### Description about the pull request

`__get__` returns `bpy_prop_array[GenericType1]` which has the same behavior as currently.
`__set__` can receive any `Iterable[GenericType1]` like any other function arguments that have `bpy_prop_array` as expected type.