### PR TITLE
Fix: slice support for bpy_prop_array and bpy_prop_collection

### DIFF
--- a/src/mods/common/analyzer/append/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/append/bpy.types.mod.rst
@@ -36,9 +36,25 @@
 
    .. method:: __getitem__(key)
 
-      :type key: int | str | slice
+      :type key: int | str
       :mod-option arg key: skip-refine
       :rtype: GenericType1
+      :mod-option rtype: skip-refine
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :rtype: tuple[GenericType1]
+      :mod-option rtype: skip-refine
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: int | str | slice
+      :mod-option arg key: skip-refine
+      :rtype: GenericType1 | tuple[GenericType1]
       :mod-option rtype: skip-refine
 
    .. method:: __setitem__(key, value)
@@ -47,10 +63,26 @@
       :mod-option arg key: skip-refine
       :type value: GenericType1
       :mod-option arg value: skip-refine
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :type value: tuple[GenericType1]
+      :mod-option arg value: skip-refine
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: int | str | slice
+      :mod-option arg key: skip-refine
+      :type value: GenericType1 | tuple[GenericType1]
+      :mod-option arg value: skip-refine
 
    .. method:: __delitem__(key)
 
-      :type key: int | str
+      :type key: int | str | slice
       :mod-option arg key: skip-refine
 
    .. method:: __iter__()

--- a/src/mods/common/analyzer/new/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/new/bpy.types.mod.rst
@@ -20,21 +20,53 @@
 
    .. method:: __getitem__(key)
 
-      :type key: int | str
+      :type key: int
       :mod-option arg key: skip-refine
       :rtype: GenericType1
+      :mod-option rtype: skip-refine
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :rtype: tuple[GenericType1]
+      :mod-option rtype: skip-refine
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :rtype: GenericType1 | tuple[GenericType1]
       :mod-option rtype: skip-refine
 
    .. method:: __setitem__(key, value)
 
-      :type key: int | str
+      :type key: int
       :mod-option arg key: skip-refine
       :type value: GenericType1
+      :mod-option arg value: skip-refine
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :type value: tuple[GenericType1]
+      :mod-option arg value: skip-refine
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :type value: GenericType1 | tuple[GenericType1]
       :mod-option arg value: skip-refine
 
    .. method:: __delitem__(key)
 
-      :type key: int | str
+      :type key: int | slice
       :mod-option arg key: skip-refine
 
    .. method:: __iter__()


### PR DESCRIPTION
`__getitem__()`, `__setitem__()` and `__delitem__()` for `bpy_prop_array` and `bpy_prop_collection` now all support passing a `slice` as a `key`, with overloads to change the return/input type to `tuple[GenericType]` when doing so.