### PR TITLE
Fix: typo in handlers callable typing

### DIFF
--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -149,7 +149,7 @@ class DataTypeRefiner(TransformerBase):
                 module_name)
             if s:
                 return [
-                    make_data_type_node("list[collections.abc.Callable[[`bpy.types.Scene`, None]]]")
+                    make_data_type_node("list[collections.abc.Callable[[`bpy.types.Scene`], None]]")
                 ]
 
         if dtype_str == "Same type with self class":

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
@@ -21,7 +21,7 @@
                 list[collections.abc.Callable[[
                 <class-ref>
                     bpy.types.Scene
-                , None]]]
+                ], None]]
     <class>
         <name>
             ClassA


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

Fix the typing of handlers list.

### Description about the pull request

The bracket for the callable arguments was not in the correct place.