### PR TITLE
Fix typing of EnumProperty items parameter

### DIFF
--- a/src/mods/common/analyzer/update/bpy.props.mod.rst
+++ b/src/mods/common/analyzer/update/bpy.props.mod.rst
@@ -1,0 +1,8 @@
+.. mod-type:: update
+
+.. module:: bpy.props
+
+.. function:: EnumProperty(items)
+
+   :type items: collections.abc.Iterable[tuple[str, str, str] | tuple[str, str, str, int] | tuple[str, str, str, str, int] | None] | collections.abc.Callable[[typing.Any, :class:`bpy.types.Context` | None], collections.abc.Iterable[tuple[str, str, str] | tuple[str, str, str, int] | tuple[str, str, str, str, int] | None]]
+   :mod-option arg items: skip-refine


### PR DESCRIPTION
Fixes #246 

A couple of issues:
- [x] The arguments are no longer keyword-only, I guess that transformation doesn't run on mod files?
- [x] I don't know if this will be compatible with a solution to #216 
- [x] I still don't like duplicating 60 lines of RST (which now need to be manually kept synchronised) just to change the type of one parameter