### PR TITLE
Update requirements.txt

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-yapf==0.25.0
-ruff==0.1.9
-docutils==0.20.1
-Pygments==2.17.2
+yapf~=0.40.2
+ruff~=0.1.9
+docutils~=0.20.1
+Pygments~=2.17.2


### PR DESCRIPTION
Update `yapf` to 0.40.2 (fixes #250)
Use "compatible" instead of explicit version matching (`~= 0.1.9` is equivalent to `>= 0.1.9, == 0.1.*`; i.e. bugfix/patch updates are allowed, but major or minor updates are not.

In my tests the generated modules were unaffected by this change. I will leave updating the other three requirements to a future PR: updating `docutils` and `pygments` to their latest versions also had no effect, but updating `ruff` to the latest version resulted in what appeared to just be formatting changes, but they might hide functional changes.