### PR TITLE
Increase type specificity for node_tree attributes

### DIFF
--- a/src/mods/common/analyzer/update/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/update/bpy.types.mod.rst
@@ -32,3 +32,99 @@
       :mod-option arg attr: skip-refine
       :type seq: collections.abc.Sequence[bool] | collections.abc.Sequence[int] | collections.abc.Sequence[float]
       :mod-option arg seq: skip-refine
+
+.. class:: FreestyleLineStyle
+
+   .. attribute:: node_tree
+
+      Node tree for node-based shaders
+
+      :type: :class:`bpy.types.ShaderNodeTree` | None
+      :mod-option: skip-refine
+
+.. class:: Light
+
+   .. attribute:: node_tree
+
+      Node tree for node based lights
+
+      :type: :class:`bpy.types.ShaderNodeTree` | None
+      :mod-option: skip-refine
+
+.. class:: Material
+
+   .. attribute:: node_tree
+
+      Node tree for node based materials
+
+      :type: :class:`bpy.types.ShaderNodeTree` | None
+      :mod-option: skip-refine
+
+.. class:: Scene
+
+   .. attribute:: node_tree
+
+      Compositing node tree
+
+      :type: :class:`bpy.types.CompositorNodeTree` | None
+      :mod-option: skip-refine
+
+.. class:: Texture
+
+   .. attribute:: node_tree
+
+      Node tree for node-based textures
+
+      :type: :class:`bpy.types.TextureNodeTree` | None
+      :mod-option: skip-refine
+
+.. class:: World
+
+   .. attribute:: node_tree
+
+      Node tree for node based worlds
+
+      :type: :class:`bpy.types.ShaderNodeTree` | None
+      :mod-option: skip-refine
+
+.. class:: CompositorNodeGroup
+
+   .. attribute:: node_tree
+
+      :type: :class:`bpy.types.CompositorNodeTree`
+
+.. class:: CompositorNodeCustomGroup
+
+   .. attribute:: node_tree
+
+      :type: :class:`bpy.types.CompositorNodeTree`
+
+.. class:: GeometryNodeGroup
+
+   .. attribute:: node_tree
+
+      :type: :class:`bpy.types.GeometryNodeTree`
+
+.. class:: GeometryNodeCustomGroup
+
+   .. attribute:: node_tree
+
+      :type: :class:`bpy.types.GeometryNodeTree`
+
+.. class:: ShaderNodeGroup
+
+   .. attribute:: node_tree
+
+      :type: :class:`bpy.types.ShaderNodeTree`
+
+.. class:: ShaderNodeCustomGroup
+
+   .. attribute:: node_tree
+
+      :type: :class:`bpy.types.ShaderNodeTree`
+
+.. class:: TextureNodeGroup
+
+   .. attribute:: node_tree
+
+      :type: :class:`bpy.types.TextureNodeTree`


### PR DESCRIPTION
The tool that automatically documents Blender's code is not able to distinguish the derived nodetrees from each other ([although it may be possible to add this functionality](https://projects.blender.org/blender/blender/issues/122737)), so `node_tree` attributes like that of `Material` were typed as a base `NodeTree` instead of the `ShaderNodeTree` actually returned. Additionally these attributes can return (and in some cases be set to) `None`.