### PR TITLE
Fix: allow foreach_get/set to accept Buffer types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,4 +14,7 @@ else:
 
 setup(
     version=release_version,
+    install_requires=[
+        'typing_extensions',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ else:
 setup(
     version=release_version,
     install_requires=[
-        'typing_extensions',
+        'typing_extensions>=4.7,<5',
     ],
 )

--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -515,6 +515,7 @@ class PyCodeWriterBase(BaseWriter):
             # import external depended modules
             wt.addln("import typing")
             wt.addln("import collections.abc")
+            wt.addln("import typing_extensions")
 
             # import depended modules
             dep_list_node = get_first_child(document, DependencyListNode)
@@ -720,7 +721,7 @@ class JsonWriter(BaseWriter):
         # import external depended modules
         json_data.append({
             "type": "external-depended-modules",
-            "contents": ["typing", "collections.abc"],
+            "contents": ["typing", "collections.abc", "typing_extensions"],
         })
 
         # import depended modules

--- a/src/mods/common/analyzer/new/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/new/bpy.types.mod.rst
@@ -20,12 +20,12 @@
 
    .. method:: foreach_get(seq)
 
-      :type seq: collections.abc.MutableSequence[GenericType1]
+      :type seq: collections.abc.MutableSequence[GenericType1] | typing_extensions.Buffer
       :mod-option arg seq: skip-refine
 
    .. method:: foreach_set(seq)
 
-      :type seq: typing.Sequence[GenericType1]
+      :type seq: collections.abc.Sequence[GenericType1] | typing_extensions.Buffer
       :mod-option arg seq: skip-refine
 
    .. method:: __getitem__(key)

--- a/src/mods/common/analyzer/update/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/update/bpy.types.mod.rst
@@ -29,14 +29,14 @@
 
       :type attr: str
       :mod-option arg attr: skip-refine
-      :type seq: collections.abc.MutableSequence[bool] | collections.abc.MutableSequence[int] | collections.abc.MutableSequence[float]
+      :type seq: collections.abc.MutableSequence[bool] | collections.abc.MutableSequence[int] | collections.abc.MutableSequence[float] | typing_extensions.Buffer
       :mod-option arg seq: skip-refine
 
    .. method:: foreach_set(attr, seq)
 
       :type attr: str
       :mod-option arg attr: skip-refine
-      :type seq: collections.abc.Sequence[bool] | collections.abc.Sequence[int] | collections.abc.Sequence[float]
+      :type seq: collections.abc.Sequence[bool] | collections.abc.Sequence[int] | collections.abc.Sequence[float] | typing_extensions.Buffer
       :mod-option arg seq: skip-refine
 
 .. class:: FreestyleLineStyle

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/code_document_node_translator_test/expect/basic/basic.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/code_document_node_translator_test/expect/basic/basic.py
@@ -56,6 +56,7 @@ Target
 
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/children/module_1.json
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/children/module_1.json
@@ -7,7 +7,8 @@
         "type": "external-depended-modules",
         "contents": [
             "typing",
-            "collections.abc"
+            "collections.abc",
+            "typing_extensions"
         ]
     },
     {

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/children/module_1.submodule_1.json
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/children/module_1.submodule_1.json
@@ -7,7 +7,8 @@
         "type": "external-depended-modules",
         "contents": [
             "typing",
-            "collections.abc"
+            "collections.abc",
+            "typing_extensions"
         ]
     },
     {

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/class/class.json
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/class/class.json
@@ -7,7 +7,8 @@
         "type": "external-depended-modules",
         "contents": [
             "typing",
-            "collections.abc"
+            "collections.abc",
+            "typing_extensions"
         ]
     },
     {

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/data/data.json
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/data/data.json
@@ -7,7 +7,8 @@
         "type": "external-depended-modules",
         "contents": [
             "typing",
-            "collections.abc"
+            "collections.abc",
+            "typing_extensions"
         ]
     },
     {

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/dependencies/dependencies.json
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/dependencies/dependencies.json
@@ -7,7 +7,8 @@
         "type": "external-depended-modules",
         "contents": [
             "typing",
-            "collections.abc"
+            "collections.abc",
+            "typing_extensions"
         ]
     },
     {

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/deprecated/deprecated.json
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/deprecated/deprecated.json
@@ -7,7 +7,8 @@
         "type": "external-depended-modules",
         "contents": [
             "typing",
-            "collections.abc"
+            "collections.abc",
+            "typing_extensions"
         ]
     },
     {

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/function/function.json
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/json_writer_test/expect/function/function.json
@@ -7,7 +7,8 @@
         "type": "external-depended-modules",
         "contents": [
             "typing",
-            "collections.abc"
+            "collections.abc",
+            "typing_extensions"
         ]
     },
     {

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/children/module_1.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/children/module_1.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 from . import submodule_1
 
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/children/module_1.submodule_1.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/children/module_1.submodule_1.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/class/class.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/class/class.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/data/data.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/data/data.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/dependencies/dependencies.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/dependencies/dependencies.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 import module_2
 
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/deprecated/deprecated.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/deprecated/deprecated.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/function/function.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/function/function.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/children/module_1.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/children/module_1.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 from . import submodule_1
 
 GenericType1 = typing.TypeVar("GenericType1")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/children/module_1.submodule_1.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/children/module_1.submodule_1.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/class/class.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/class/class.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/data/data.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/data/data.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/dependencies/dependencies.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/dependencies/dependencies.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 import module_2
 
 GenericType1 = typing.TypeVar("GenericType1")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/deprecated/deprecated.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/deprecated/deprecated.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/function/function.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/function/function.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/exceptional/module_exceptional/__init__.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/exceptional/module_exceptional/__init__.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/exceptional/module_exceptional/__init__.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/exceptional/module_exceptional/__init__.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/__init__.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/__init__.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 import module_1.submodule_1
 
 from . import submodule_1

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/__init__.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/__init__.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 import module_1.submodule_1
 
 from . import submodule_1

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/submodule_1/__init__.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/submodule_1/__init__.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/submodule_1/__init__.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/submodule_1/__init__.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 import module_1
 import module_1.submodule_1
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 import module_1
 import module_1.submodule_1
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/single/module_abc/__init__.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/single/module_abc/__init__.py
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/single/module_abc/__init__.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/single/module_abc/__init__.pyi
@@ -1,5 +1,6 @@
 import typing
 import collections.abc
+import typing_extensions
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")


### PR DESCRIPTION
As per #161:
> In .pyi files, the most recent syntax of python can be used, as it is only used for static analysis.

[`collections.abc.Buffer`](https://docs.python.org/3/library/collections.abc.html#collections.abc.Buffer) was added in Python 3.12 for typing classes that implement the buffer protocol—it is not possible to specify the contained type or mutability of the buffer.

Fixes #257