### PR TITLE
Remove assignment to slices & keys and delitem from bpy_prop_collection

### DIFF
--- a/src/mods/common/analyzer/append/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/append/bpy.types.mod.rst
@@ -59,31 +59,10 @@
 
    .. method:: __setitem__(key, value)
 
-      :type key: int | str
+      :type key: int
       :mod-option arg key: skip-refine
       :type value: GenericType1
       :mod-option arg value: skip-refine
-      :option function: overload
-
-   .. method:: __setitem__(key, value)
-
-      :type key: slice
-      :mod-option arg key: skip-refine
-      :type value: tuple[GenericType1]
-      :mod-option arg value: skip-refine
-      :option function: overload
-
-   .. method:: __setitem__(key, value)
-
-      :type key: int | str | slice
-      :mod-option arg key: skip-refine
-      :type value: GenericType1 | tuple[GenericType1]
-      :mod-option arg value: skip-refine
-
-   .. method:: __delitem__(key)
-
-      :type key: int | str | slice
-      :mod-option arg key: skip-refine
 
    .. method:: __iter__()
 

--- a/src/mods/common/analyzer/new/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/new/bpy.types.mod.rst
@@ -76,7 +76,7 @@
 
    .. method:: __delitem__(key)
 
-      :type key: int | slice
+      :type key: int
       :mod-option arg key: skip-refine
 
    .. method:: __iter__()


### PR DESCRIPTION
`bpy_prop_collection` does not currently support assignment to slices or keys (only int indices); and while it does have a `__delitem__`, it just raises a `TypeError` "del bpy_prop_collection[key]: not supported".

`bpy_prop_array` does not support deleting slices.