### PR TITLE
Array of boolean consistency with array of int/float

### DIFF
--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -229,7 +229,9 @@ class DataTypeRefiner(TransformerBase):
             return [make_data_type_node("bool")]
         # Ex: boolean array of 3 items, (optional)
         if REGEX_MATCH_DATA_TYPE_BOOLEAN_ARRAY_OF.match(dtype_str):
-            return [make_data_type_node("list[bool]")]
+            if variable_kind == 'FUNC_ARG':
+                return [make_data_type_node("collections.abc.Iterable[bool]")]
+            return [make_data_type_node("`bpy.types.bpy_prop_array`[bool]")]
 
         if dtype_str == "boolean":
             return [make_data_type_node("bool")]

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type.xml
@@ -170,6 +170,22 @@
         <data-type-list>
             <data-type>
                 boolean array of 3 items
+    <function function_type="function">
+        <name>
+            function_1
+        <description>
+        <argument-list>
+            <argument argument_type="arg">
+                <name>
+                    arg_boolean_array_of
+                <description>
+                <default-value>
+                <data-type-list>
+                    <data-type>
+                        boolean array of 3 items
+        <return>
+            <description>
+            <data-type-list>
     <data>
         <name>
             data_boolean

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
@@ -171,7 +171,25 @@
         <description>
         <data-type-list>
             <data-type option="never none">
-                list[bool]
+                <class-ref>
+                    bpy.types.bpy_prop_array
+                [bool]
+    <function function_type="function">
+        <name>
+            function_1
+        <description>
+        <argument-list>
+            <argument argument_type="arg">
+                <name>
+                    arg_boolean_array_of
+                <description>
+                <default-value>
+                <data-type-list>
+                    <data-type option="never none">
+                        collections.abc.Iterable[bool]
+        <return>
+            <description>
+            <data-type-list>
     <data>
         <name>
             data_boolean

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/input/various_data_type.rst
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/input/various_data_type.rst
@@ -87,6 +87,10 @@
 
    :type: boolean array of 3 items
 
+.. function:: function_1(arg_boolean_array_of)
+
+   :type arg_boolean_array_of: boolean array of 3 items
+
 .. data:: data_boolean
 
    :type: boolean


### PR DESCRIPTION
`boolean array of n items` was being typed as `list[bool]`, which was then incompatible with `tuple` default values, and was inconsistent with `int/float array of n items` which is typed as `Iterable` or `bpy_prop_array` depending on the application.