### PR TITLE
Fix: get/set slice returns/accepts more than one item

### DIFF
--- a/src/mods/common/analyzer/append/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/append/bpy.types.mod.rst
@@ -46,7 +46,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: tuple[GenericType1]
+      :rtype: tuple[GenericType1, ...]
       :mod-option rtype: skip-refine
       :option function: overload
 
@@ -54,7 +54,7 @@
 
       :type key: int | str | slice
       :mod-option arg key: skip-refine
-      :rtype: GenericType1 | tuple[GenericType1]
+      :rtype: GenericType1 | tuple[GenericType1, ...]
       :mod-option rtype: skip-refine
 
    .. method:: __setitem__(key, value)

--- a/src/mods/common/analyzer/new/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/new/bpy.types.mod.rst
@@ -40,7 +40,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: tuple[GenericType1]
+      :rtype: tuple[GenericType1, ...]
       :mod-option rtype: skip-refine
       :option function: overload
 
@@ -48,7 +48,7 @@
 
       :type key: int | slice
       :mod-option arg key: skip-refine
-      :rtype: GenericType1 | tuple[GenericType1]
+      :rtype: GenericType1 | tuple[GenericType1, ...]
       :mod-option rtype: skip-refine
 
    .. method:: __setitem__(key, value)
@@ -63,7 +63,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :type value: tuple[GenericType1]
+      :type value: collections.abc.Iterable[GenericType1]
       :mod-option arg value: skip-refine
       :option function: overload
 
@@ -71,7 +71,7 @@
 
       :type key: int | slice
       :mod-option arg key: skip-refine
-      :type value: GenericType1 | tuple[GenericType1]
+      :type value: GenericType1 | collections.abc.Iterable[GenericType1]
       :mod-option arg value: skip-refine
 
    .. method:: __delitem__(key)


### PR DESCRIPTION
I keep making the mistake of writing a single-item tuple when I mean a homogenous tuple of undefined length, and nobody caught me on it.

Perhaps we should look into implementing tests for mod file changes?

Also the input for assignment does not have to a tuple, it can be any iterable.