### PR TITLE
Update: Add slice support to `mathutils` classes

### DIFF
--- a/src/mods/common/analyzer/append/mathutils.mod.rst
+++ b/src/mods/common/analyzer/append/mathutils.mod.rst
@@ -78,6 +78,43 @@
 
       :type key: int
       :rtype: float
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :rtype: tuple[float, ...]
+      :mod-option rtype: skip-refine
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :rtype: float | tuple[float, ...]
+      :mod-option rtype: skip-refine
+
+   .. method:: __setitem__(key, value)
+
+      :type key: int
+      :type value: float
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :type value: collections.abc.Iterable[float]
+      :mod-option arg value: skip-refine
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :type value: float | collections.abc.Iterable[float]
+      :mod-option arg value: skip-refine
 
 .. class:: Euler
 
@@ -95,6 +132,43 @@
 
       :type key: int
       :rtype: float
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :rtype: tuple[float, ...]
+      :mod-option rtype: skip-refine
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :rtype: float | tuple[float, ...]
+      :mod-option rtype: skip-refine
+
+   .. method:: __setitem__(key, value)
+
+      :type key: int
+      :type value: float
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :type value: collections.abc.Iterable[float]
+      :mod-option arg value: skip-refine
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :type value: float | collections.abc.Iterable[float]
+      :mod-option arg value: skip-refine
 
 .. class:: Matrix
 
@@ -112,6 +186,44 @@
 
       :type key: int
       :rtype: :class:`Vector`
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :rtype: tuple[:class:`Vector`, ...]
+      :mod-option rtype: skip-refine
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :rtype: float | tuple[:class:`Vector`, ...]
+      :mod-option rtype: skip-refine
+
+   .. method:: __setitem__(key, value)
+
+      :type key: int
+      :type value: :class:`Vector` | collections.abc.Iterable[float]
+      :mod-option arg value: skip-refine
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :type value: collections.abc.Iterable[:class:`Vector` | collections.abc.Iterable[float]]
+      :mod-option arg value: skip-refine
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :type value: :class:`Vector` | collections.abc.Iterable[float] | collections.abc.Iterable[:class:`Vector` | collections.abc.Iterable[float]]
+      :mod-option arg value: skip-refine
 
    .. method:: __len__()
 
@@ -189,12 +301,43 @@
 
       :type key: int
       :rtype: float
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :rtype: tuple[float, ...]
+      :mod-option rtype: skip-refine
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :rtype: float | tuple[float, ...]
+      :mod-option rtype: skip-refine
 
    .. method:: __setitem__(key, value)
 
       :type key: int
       :type value: float
-      :rtype: float
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :type value: collections.abc.Iterable[float]
+      :mod-option arg value: skip-refine
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :type value: float | collections.abc.Iterable[float]
+      :mod-option arg value: skip-refine
 
    .. method:: __add__(other)
 
@@ -268,12 +411,43 @@
 
       :type key: int
       :rtype: float
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :rtype: tuple[float, ...]
+      :mod-option rtype: skip-refine
+      :option function: overload
+
+   .. method:: __getitem__(key)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :rtype: float | tuple[float, ...]
+      :mod-option rtype: skip-refine
 
    .. method:: __setitem__(key, value)
 
       :type key: int
       :type value: float
-      :rtype: float
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: slice
+      :mod-option arg key: skip-refine
+      :type value: collections.abc.Iterable[float]
+      :mod-option arg value: skip-refine
+      :option function: overload
+
+   .. method:: __setitem__(key, value)
+
+      :type key: int | slice
+      :mod-option arg key: skip-refine
+      :type value: float | collections.abc.Iterable[float]
+      :mod-option arg value: skip-refine
 
    .. method:: __neg__()
 

--- a/src/mods/common/analyzer/append/mathutils.mod.rst
+++ b/src/mods/common/analyzer/append/mathutils.mod.rst
@@ -88,13 +88,6 @@
       :mod-option rtype: skip-refine
       :option function: overload
 
-   .. method:: __getitem__(key)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :rtype: float | tuple[float, ...]
-      :mod-option rtype: skip-refine
-
    .. method:: __setitem__(key, value)
 
       :type key: int
@@ -108,13 +101,6 @@
       :type value: collections.abc.Iterable[float]
       :mod-option arg value: skip-refine
       :option function: overload
-
-   .. method:: __setitem__(key, value)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :type value: float | collections.abc.Iterable[float]
-      :mod-option arg value: skip-refine
 
 .. class:: Euler
 
@@ -142,13 +128,6 @@
       :mod-option rtype: skip-refine
       :option function: overload
 
-   .. method:: __getitem__(key)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :rtype: float | tuple[float, ...]
-      :mod-option rtype: skip-refine
-
    .. method:: __setitem__(key, value)
 
       :type key: int
@@ -162,13 +141,6 @@
       :type value: collections.abc.Iterable[float]
       :mod-option arg value: skip-refine
       :option function: overload
-
-   .. method:: __setitem__(key, value)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :type value: float | collections.abc.Iterable[float]
-      :mod-option arg value: skip-refine
 
 .. class:: Matrix
 
@@ -196,13 +168,6 @@
       :mod-option rtype: skip-refine
       :option function: overload
 
-   .. method:: __getitem__(key)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :rtype: float | tuple[:class:`Vector`, ...]
-      :mod-option rtype: skip-refine
-
    .. method:: __setitem__(key, value)
 
       :type key: int
@@ -217,13 +182,6 @@
       :type value: collections.abc.Iterable[:class:`Vector` | collections.abc.Iterable[float]]
       :mod-option arg value: skip-refine
       :option function: overload
-
-   .. method:: __setitem__(key, value)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :type value: :class:`Vector` | collections.abc.Iterable[float] | collections.abc.Iterable[:class:`Vector` | collections.abc.Iterable[float]]
-      :mod-option arg value: skip-refine
 
    .. method:: __len__()
 
@@ -311,13 +269,6 @@
       :mod-option rtype: skip-refine
       :option function: overload
 
-   .. method:: __getitem__(key)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :rtype: float | tuple[float, ...]
-      :mod-option rtype: skip-refine
-
    .. method:: __setitem__(key, value)
 
       :type key: int
@@ -331,13 +282,6 @@
       :type value: collections.abc.Iterable[float]
       :mod-option arg value: skip-refine
       :option function: overload
-
-   .. method:: __setitem__(key, value)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :type value: float | collections.abc.Iterable[float]
-      :mod-option arg value: skip-refine
 
    .. method:: __add__(other)
 
@@ -421,13 +365,6 @@
       :mod-option rtype: skip-refine
       :option function: overload
 
-   .. method:: __getitem__(key)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :rtype: float | tuple[float, ...]
-      :mod-option rtype: skip-refine
-
    .. method:: __setitem__(key, value)
 
       :type key: int
@@ -441,13 +378,6 @@
       :type value: collections.abc.Iterable[float]
       :mod-option arg value: skip-refine
       :option function: overload
-
-   .. method:: __setitem__(key, value)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :type value: float | collections.abc.Iterable[float]
-      :mod-option arg value: skip-refine
 
    .. method:: __neg__()
 


### PR DESCRIPTION
- Adds slicing support to `Color`, `Euler`, `Quaternion`, `Vector` and `Matrix`.
- Adds `__setitem__` for `Color`, `Euler` and `Matrix` which did not previously have them.
- Removes return value from `__setitem__` for `Quaternion` and `Vector`.

Resolves #274 