### PR TITLE
Remove runtime definition for overloaded functions

### DIFF
--- a/src/mods/common/analyzer/append/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/append/bpy.types.mod.rst
@@ -50,13 +50,6 @@
       :mod-option rtype: skip-refine
       :option function: overload
 
-   .. method:: __getitem__(key)
-
-      :type key: int | str | slice
-      :mod-option arg key: skip-refine
-      :rtype: GenericType1 | tuple[GenericType1, ...]
-      :mod-option rtype: skip-refine
-
    .. method:: __setitem__(key, value)
 
       :type key: int

--- a/src/mods/common/analyzer/append/mathutils.mod.rst
+++ b/src/mods/common/analyzer/append/mathutils.mod.rst
@@ -214,11 +214,6 @@
       :rtype: :class:`Vector`
       :option function: overload
 
-   .. method:: __matmul__(other)
-
-      :type other: :class:`Matrix`, :class:`Vector`
-      :rtype: :class:`Matrix`, :class:`Vector`
-
    .. method:: __radd__(other)
 
       :type other: :class:`Matrix`
@@ -309,11 +304,6 @@
       :type other: :class:`Vector`
       :rtype: :class:`Vector`
       :option function: overload
-
-   .. method:: __matmul__(other)
-
-      :type other: :class:`Vector`, :class:`Quaternion`
-      :rtype: :class:`Vector`, :class:`Quaternion`
 
    .. method:: __radd__(other)
 
@@ -414,11 +404,6 @@
       :type other: :class:`Matrix`
       :rtype: :class:`Vector`
       :option function: overload
-
-   .. method:: __matmul__(other)
-
-      :type other: :class:`Vector`, :class:`Matrix`
-      :rtype: :class:`Vector`, float
 
    .. method:: __radd__(other)
 

--- a/src/mods/common/analyzer/new/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/new/bpy.types.mod.rst
@@ -44,13 +44,6 @@
       :mod-option rtype: skip-refine
       :option function: overload
 
-   .. method:: __getitem__(key)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :rtype: GenericType1 | tuple[GenericType1, ...]
-      :mod-option rtype: skip-refine
-
    .. method:: __setitem__(key, value)
 
       :type key: int
@@ -66,13 +59,6 @@
       :type value: collections.abc.Iterable[GenericType1]
       :mod-option arg value: skip-refine
       :option function: overload
-
-   .. method:: __setitem__(key, value)
-
-      :type key: int | slice
-      :mod-option arg key: skip-refine
-      :type value: GenericType1 | collections.abc.Iterable[GenericType1]
-      :mod-option arg value: skip-refine
 
    .. method:: __delitem__(key)
 


### PR DESCRIPTION
As discussed in #278 the non-`@overload`-decorated function definition that follows all `@overload`-decorated functions is the runtime implementation of the function, which should not be included in type stubs. This PR removes existing functions of this kind from the mod files.