### PR TITLE
Fix: Import Self from typing_extensions instead of typing

### DIFF
--- a/src/fake_bpy_module/transformer/self_rewriter.py
+++ b/src/fake_bpy_module/transformer/self_rewriter.py
@@ -39,7 +39,7 @@ class SelfRewriter(TransformerBase):
             dtype = dtype_node.to_string()
             if dtype == class_name:
                 new_dtype_node = DataTypeNode()
-                new_dtype_node.append(nodes.Text("typing.Self"))
+                new_dtype_node.append(nodes.Text("typing_extensions.Self"))
                 self._replace(dtype_node, new_dtype_node)
 
     def _rewrite_same_class_to_self(self, document: nodes.document) -> None:

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/self_rewriter_test/expect/basic_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/self_rewriter_test/expect/basic_transformed.xml
@@ -17,7 +17,7 @@
                 <description>
                 <data-type-list>
                     <data-type>
-                        typing.Self
+                        typing_extensions.Self
             <attribute>
                 <name>
                     attr_2
@@ -39,7 +39,7 @@
                         <default-value>
                         <data-type-list>
                             <data-type>
-                                typing.Self
+                                typing_extensions.Self
                     <argument argument_type="arg">
                         <name>
                             arg_2
@@ -53,7 +53,7 @@
                     <description>
                     <data-type-list>
                         <data-type>
-                            typing.Self
+                            typing_extensions.Self
     <class>
         <name>
             ClassB


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request
For Python version less than 3.11, type checkers (at least Pyright) will complain that `typing.Self` does not exist.

### Description about the pull request
This PR imports `Self` from `typing_extensions` instead of `typing`.
