### PR TITLE
Fix: Copy attributes when rewriting Self type for optional type

### DIFF
--- a/src/fake_bpy_module/transformer/self_rewriter.py
+++ b/src/fake_bpy_module/transformer/self_rewriter.py
@@ -40,6 +40,7 @@ class SelfRewriter(TransformerBase):
             if dtype == class_name:
                 new_dtype_node = DataTypeNode()
                 new_dtype_node.append(nodes.Text("typing_extensions.Self"))
+                new_dtype_node.attributes = dtype_node.attributes
                 self._replace(dtype_node, new_dtype_node)
 
     def _rewrite_same_class_to_self(self, document: nodes.document) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

The fix of #270 caused a regression of #243 for self types that are optional.

### Description about the pull request

The `option` attributes which can `accept none` or `never none` was not copied when rewriting to the self type.
To keep the info that the type is optional `attributes` is assigned to the new node.
