### PR TITLE
Fix: Re-export child modules

### DIFF
--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -563,7 +563,7 @@ class PyCodeWriterBase(BaseWriter):
                 child_nodes = find_children(child_list_node, ChildModuleNode)
                 children = [node.astext() for node in child_nodes]
                 for child in sorted(children):
-                    wt.addln(f"from . import {child}")
+                    wt.addln(f"from . import {child} as {child}")
             if len(children) > 0:
                 wt.new_line()
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/children/module_1.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_code_writer_test/expect/children/module_1.py
@@ -1,7 +1,7 @@
 import typing
 import collections.abc
 import typing_extensions
-from . import submodule_1
+from . import submodule_1 as submodule_1
 
 
 GenericType1 = typing.TypeVar("GenericType1")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/children/module_1.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/py_interface_writer_test/expect/children/module_1.pyi
@@ -1,7 +1,7 @@
 import typing
 import collections.abc
 import typing_extensions
-from . import submodule_1
+from . import submodule_1 as submodule_1
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/__init__.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/__init__.py
@@ -3,7 +3,7 @@ import collections.abc
 import typing_extensions
 import module_1.submodule_1
 
-from . import submodule_1
+from . import submodule_1 as submodule_1
 
 
 GenericType1 = typing.TypeVar("GenericType1")

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/__init__.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_1/__init__.pyi
@@ -3,7 +3,7 @@ import collections.abc
 import typing_extensions
 import module_1.submodule_1
 
-from . import submodule_1
+from . import submodule_1 as submodule_1
 
 GenericType1 = typing.TypeVar("GenericType1")
 GenericType2 = typing.TypeVar("GenericType2")


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

IntelliSense was not working in PyCharm because the child modules were not re-exported.
The imports should be of the form `from . import ops as ops` instead of `from . import ops` (c.f. https://typing.readthedocs.io/en/latest/reference/stubs.html#imports)
This issue was found by McPhail and reported on Discord.

Before | After
--- | ---
![Screenshot from 2024-08-15 14-03-24](https://github.com/user-attachments/assets/e24220b2-085b-492d-a4c8-a128976643f0) ![Screenshot from 2024-08-15 14-03-40](https://github.com/user-attachments/assets/40aa2ee7-da86-424f-9c6b-e247a2299e68) | ![Screenshot from 2024-08-15 14-04-06](https://github.com/user-attachments/assets/c77bfcb5-20c6-48bd-b82a-30c096b86af7) ![Screenshot from 2024-08-15 14-03-55](https://github.com/user-attachments/assets/8adb1681-dc1f-4da1-b7a3-ba0c3d255c4d)
