### PR TITLE
Fix: parsing .rst on windows

### DIFF
--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -85,7 +85,7 @@ def get_rna_enum_items(dtype_str: str) -> str:
     rna_enum_path = (Path(config.get_input_dir())
                      / "bpy_types_enum_items"
                      / f"{rna_enum_name}.rst")
-    content = rna_enum_path.read_text()
+    content = rna_enum_path.read_text(encoding="utf-8")
     doctree = publish_doctree(content).asdom()
     return ", ".join(
         repr(e.firstChild.nodeValue)


### PR DESCRIPTION
It was failing with error because of the symbol "←" in one of the files (event_type_items.rst)

```
path \fake-bpy-module\src\gen_module-tmp\sphinx-in\bpy_types_enum_items\event_type_items.rst
Traceback (most recent call last):
  File "\fake-bpy-module\src\gen.py", line 183, in <module>
    main()
  File "\fake-bpy-module\src\gen.py", line 179, in main
    generate(rst_files, mod_files)
  File "\fake-bpy-module\src\gen.py", line 13, in generate
    documents = fbm.transform(documents, mod_files)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\fake-bpy-module\src\fake_bpy_module\transformer\transformer.py", line 59, in transform
    return t.transform(documents)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "\fake-bpy-module\src\fake_bpy_module\transformer\transformer.py", line 145, in transform
    transformer.apply(**apply_params)
  File "\fake-bpy-module\src\fake_bpy_module\transformer\data_type_refiner.py", line 889, in apply
    self._refine(document)
  File "\fake-bpy-module\src\fake_bpy_module\transformer\data_type_refiner.py", line 837, in _refine
    refine(dtype_list_node, module_name, 'CLS_ATTR',
  File "\fake-bpy-module\src\fake_bpy_module\transformer\data_type_refiner.py", line 787, in refine
    new_dtype_nodes.extend(self._get_refined_data_type(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\fake-bpy-module\src\fake_bpy_module\transformer\data_type_refiner.py", line 647, in _get_refined_data_type
    result = self._get_refined_data_type_internal(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\fake-bpy-module\src\fake_bpy_module\transformer\data_type_refiner.py", line 702, in _get_refined_data_type_internal
    result = self._get_refined_data_type_fast(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\fake-bpy-module\src\fake_bpy_module\transformer\data_type_refiner.py", line 259, in _get_refined_data_type_fast
    enum_values = get_rna_enum_items(dtype_str)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\fake-bpy-module\src\fake_bpy_module\transformer\data_type_refiner.py", line 89, in get_rna_enum_items
    content = rna_enum_path.read_text()
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "\Python311\Lib\pathlib.py", line 1059, in read_text
    return f.read()
           ^^^^^^^^
  File "\Python311\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 2064: character maps to <undefined>
```
