### PR TITLE
Fix: remove adding "never none" for "readonly" properties

### DIFF
--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -606,10 +606,6 @@ class DataTypeRefiner(TransformerBase):
                                f"{dtype_str} -> {stripped}")
                     dtype_str = stripped
 
-            # If readonly is specified, we should add never none as well.
-            if "readonly" in option_results:
-                option_results.append("never none")
-
             option_results = sorted(set(option_results))
 
             # Active object can accept None.

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/option_rna_based_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/option_rna_based_transformed.xml
@@ -26,7 +26,7 @@
                     function_1 arg_readonly description
                 <default-value>
                 <data-type-list>
-                    <data-type option="never none,readonly">
+                    <data-type option="readonly">
                         int
             <argument argument_type="arg">
                 <name>


### PR DESCRIPTION
As it's not true, e.g. `bpy.types.ID.library` can be None though it is readonly.