### PR TITLE
Fix bpy.typing confused as std typing

### DIFF
--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -647,7 +647,8 @@ class PyCodeWriterBase(BaseWriter):
                 child_nodes = find_children(child_list_node, ChildModuleNode)
                 children = [node.astext() for node in child_nodes]
                 for child in sorted(children):
-                    if child == "typing_enums":
+                    # Skip typing module as it is not available at runtime
+                    if child == "typing":
                         continue
                     wt.addln(f"from . import {child} as {child}")
             if len(children) > 0:

--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -647,6 +647,8 @@ class PyCodeWriterBase(BaseWriter):
                 child_nodes = find_children(child_list_node, ChildModuleNode)
                 children = [node.astext() for node in child_nodes]
                 for child in sorted(children):
+                    if child == "typing":
+                        continue
                     wt.addln(f"from . import {child} as {child}")
             if len(children) > 0:
                 wt.new_line()

--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -647,6 +647,8 @@ class PyCodeWriterBase(BaseWriter):
                 child_nodes = find_children(child_list_node, ChildModuleNode)
                 children = [node.astext() for node in child_nodes]
                 for child in sorted(children):
+                    if child == "typing_enums":
+                        continue
                     wt.addln(f"from . import {child} as {child}")
             if len(children) > 0:
                 wt.new_line()

--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -647,8 +647,6 @@ class PyCodeWriterBase(BaseWriter):
                 child_nodes = find_children(child_list_node, ChildModuleNode)
                 children = [node.astext() for node in child_nodes]
                 for child in sorted(children):
-                    if child == "typing":
-                        continue
                     wt.addln(f"from . import {child} as {child}")
             if len(children) > 0:
                 wt.new_line()

--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -648,7 +648,7 @@ class PyCodeWriterBase(BaseWriter):
                 children = [node.astext() for node in child_nodes]
                 for child in sorted(children):
                     # Skip typing module as it is not available at runtime
-                    if child == "typing":
+                    if child == "_typing":
                         continue
                     wt.addln(f"from . import {child} as {child}")
             if len(children) > 0:

--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -272,7 +272,7 @@ class DataTypeRefiner(TransformerBase):
             dtype_node = DataTypeNode()
             append_child(dtype_node, nodes.Text("set["))
             append_child(dtype_node,
-                         EnumRef(text=f"bpy.typing.{enum_literal_type}"))
+                         EnumRef(text=f"bpy._typing.rna_enums.{enum_literal_type}"))
             append_child(dtype_node, nodes.Text("]"))
             return [dtype_node]
 
@@ -281,7 +281,7 @@ class DataTypeRefiner(TransformerBase):
             enum_literal_type = get_rna_enum_name(dtype_str)
             dtype_node = DataTypeNode()
             append_child(dtype_node,
-                         EnumRef(text=f"bpy.typing.{enum_literal_type}"))
+                         EnumRef(text=f"bpy._typing.rna_enums.{enum_literal_type}"))
             return [dtype_node]
 
         # [Ex] Enumerated constant
@@ -870,14 +870,14 @@ class DataTypeRefiner(TransformerBase):
                 dtype_node = DataTypeNode()
                 append_child(dtype_node, nodes.Text("set["))
                 append_child(dtype_node,
-                             EnumRef(text=f"bpy.typing.{enum_literal_type}"))
+                             EnumRef(text=f"bpy._typing.rna_enums.{enum_literal_type}"))
                 append_child(dtype_node, nodes.Text("]"))
                 return [dtype_node], True
 
             enum_literal_type = get_rna_enum_name(description_str)
             dtype_node = DataTypeNode()
             append_child(dtype_node,
-                         EnumRef(text=f"bpy.typing.{enum_literal_type}"))
+                         EnumRef(text=f"bpy._typing.rna_enums.{enum_literal_type}"))
             return [dtype_node], True
 
         return [], False

--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -272,7 +272,7 @@ class DataTypeRefiner(TransformerBase):
             dtype_node = DataTypeNode()
             append_child(dtype_node, nodes.Text("set["))
             append_child(dtype_node,
-                         EnumRef(text=f"bpy.typing.{enum_literal_type}"))
+                         EnumRef(text=f"bpy.typing_enums.{enum_literal_type}"))
             append_child(dtype_node, nodes.Text("]"))
             return [dtype_node]
 
@@ -281,7 +281,7 @@ class DataTypeRefiner(TransformerBase):
             enum_literal_type = get_rna_enum_name(dtype_str)
             dtype_node = DataTypeNode()
             append_child(dtype_node,
-                         EnumRef(text=f"bpy.typing.{enum_literal_type}"))
+                         EnumRef(text=f"bpy.typing_enums.{enum_literal_type}"))
             return [dtype_node]
 
         # [Ex] Enumerated constant
@@ -870,14 +870,14 @@ class DataTypeRefiner(TransformerBase):
                 dtype_node = DataTypeNode()
                 append_child(dtype_node, nodes.Text("set["))
                 append_child(dtype_node,
-                             EnumRef(text=f"bpy.typing.{enum_literal_type}"))
+                             EnumRef(text=f"bpy.typing_enums.{enum_literal_type}"))
                 append_child(dtype_node, nodes.Text("]"))
                 return [dtype_node], True
 
             enum_literal_type = get_rna_enum_name(description_str)
             dtype_node = DataTypeNode()
             append_child(dtype_node,
-                         EnumRef(text=f"bpy.typing.{enum_literal_type}"))
+                         EnumRef(text=f"bpy.typing_enums.{enum_literal_type}"))
             return [dtype_node], True
 
         return [], False

--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -272,7 +272,7 @@ class DataTypeRefiner(TransformerBase):
             dtype_node = DataTypeNode()
             append_child(dtype_node, nodes.Text("set["))
             append_child(dtype_node,
-                         EnumRef(text=f"bpy.typing_enums.{enum_literal_type}"))
+                         EnumRef(text=f"bpy.typing.{enum_literal_type}"))
             append_child(dtype_node, nodes.Text("]"))
             return [dtype_node]
 
@@ -281,7 +281,7 @@ class DataTypeRefiner(TransformerBase):
             enum_literal_type = get_rna_enum_name(dtype_str)
             dtype_node = DataTypeNode()
             append_child(dtype_node,
-                         EnumRef(text=f"bpy.typing_enums.{enum_literal_type}"))
+                         EnumRef(text=f"bpy.typing.{enum_literal_type}"))
             return [dtype_node]
 
         # [Ex] Enumerated constant
@@ -870,14 +870,14 @@ class DataTypeRefiner(TransformerBase):
                 dtype_node = DataTypeNode()
                 append_child(dtype_node, nodes.Text("set["))
                 append_child(dtype_node,
-                             EnumRef(text=f"bpy.typing_enums.{enum_literal_type}"))
+                             EnumRef(text=f"bpy.typing.{enum_literal_type}"))
                 append_child(dtype_node, nodes.Text("]"))
                 return [dtype_node], True
 
             enum_literal_type = get_rna_enum_name(description_str)
             dtype_node = DataTypeNode()
             append_child(dtype_node,
-                         EnumRef(text=f"bpy.typing_enums.{enum_literal_type}"))
+                         EnumRef(text=f"bpy.typing.{enum_literal_type}"))
             return [dtype_node], True
 
         return [], False

--- a/src/fake_bpy_module/transformer/rna_enum_converter.py
+++ b/src/fake_bpy_module/transformer/rna_enum_converter.py
@@ -46,7 +46,7 @@ class RnaEnumConverter(TransformerBase):
         document.append(source_file_node)
 
         module_node = ModuleNode.create_template()
-        module_node.element(NameNode).add_text("bpy.typing_enums")
+        module_node.element(NameNode).add_text("bpy.typing")
         document.append(module_node)
 
         enum_node = EnumNode.create_template()

--- a/src/fake_bpy_module/transformer/rna_enum_converter.py
+++ b/src/fake_bpy_module/transformer/rna_enum_converter.py
@@ -46,7 +46,7 @@ class RnaEnumConverter(TransformerBase):
         document.append(source_file_node)
 
         module_node = ModuleNode.create_template()
-        module_node.element(NameNode).add_text("bpy.typing")
+        module_node.element(NameNode).add_text("bpy.typing_enums")
         document.append(module_node)
 
         enum_node = EnumNode.create_template()

--- a/src/fake_bpy_module/transformer/rna_enum_converter.py
+++ b/src/fake_bpy_module/transformer/rna_enum_converter.py
@@ -46,7 +46,7 @@ class RnaEnumConverter(TransformerBase):
         document.append(source_file_node)
 
         module_node = ModuleNode.create_template()
-        module_node.element(NameNode).add_text("bpy.typing")
+        module_node.element(NameNode).add_text("bpy._typing.rna_enums")
         document.append(module_node)
 
         enum_node = EnumNode.create_template()

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.py
@@ -1,7 +1,7 @@
 import typing
 import collections.abc
 import typing_extensions
-import bpy.typing
+import bpy.typing_enums
 import module_1
 import module_1.submodule_1
 
@@ -9,9 +9,9 @@ import module_1.submodule_1
 def function_1(
     arg_1: int,
     arg_2: module_1.ClassA,
-    arg_3: bpy.typing.Enum1,
-    arg_4: set[bpy.typing.Enum1],
-    arg_5: bpy.typing.Enum1,
+    arg_3: bpy.typing_enums.Enum1,
+    arg_4: set[bpy.typing_enums.Enum1],
+    arg_5: bpy.typing_enums.Enum1,
 ) -> module_1.submodule_1.BaseClass1:
     """function_1 description
 
@@ -20,11 +20,11 @@ def function_1(
     :param arg_2: function_1 arg_2 description
     :type arg_2: module_1.ClassA
     :param arg_3: function_1 arg_3 description
-    :type arg_3: bpy.typing.Enum1
+    :type arg_3: bpy.typing_enums.Enum1
     :param arg_4: Enumerator in `rna_enum_enum1`.
-    :type arg_4: set[bpy.typing.Enum1]
+    :type arg_4: set[bpy.typing_enums.Enum1]
     :param arg_5: job type in `rna_enum_enum1`.
-    :type arg_5: bpy.typing.Enum1
+    :type arg_5: bpy.typing_enums.Enum1
     :return: method_1 return description
     :rtype: module_1.submodule_1.BaseClass1
     """

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.py
@@ -1,7 +1,7 @@
 import typing
 import collections.abc
 import typing_extensions
-import bpy.typing_enums
+import bpy.typing
 import module_1
 import module_1.submodule_1
 
@@ -9,9 +9,9 @@ import module_1.submodule_1
 def function_1(
     arg_1: int,
     arg_2: module_1.ClassA,
-    arg_3: bpy.typing_enums.Enum1,
-    arg_4: set[bpy.typing_enums.Enum1],
-    arg_5: bpy.typing_enums.Enum1,
+    arg_3: bpy.typing.Enum1,
+    arg_4: set[bpy.typing.Enum1],
+    arg_5: bpy.typing.Enum1,
 ) -> module_1.submodule_1.BaseClass1:
     """function_1 description
 
@@ -20,11 +20,11 @@ def function_1(
     :param arg_2: function_1 arg_2 description
     :type arg_2: module_1.ClassA
     :param arg_3: function_1 arg_3 description
-    :type arg_3: bpy.typing_enums.Enum1
+    :type arg_3: bpy.typing.Enum1
     :param arg_4: Enumerator in `rna_enum_enum1`.
-    :type arg_4: set[bpy.typing_enums.Enum1]
+    :type arg_4: set[bpy.typing.Enum1]
     :param arg_5: job type in `rna_enum_enum1`.
-    :type arg_5: bpy.typing_enums.Enum1
+    :type arg_5: bpy.typing.Enum1
     :return: method_1 return description
     :rtype: module_1.submodule_1.BaseClass1
     """

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.py
@@ -1,7 +1,7 @@
 import typing
 import collections.abc
 import typing_extensions
-import bpy.typing
+import bpy._typing.rna_enums
 import module_1
 import module_1.submodule_1
 
@@ -9,9 +9,9 @@ import module_1.submodule_1
 def function_1(
     arg_1: int,
     arg_2: module_1.ClassA,
-    arg_3: bpy.typing.Enum1,
-    arg_4: set[bpy.typing.Enum1],
-    arg_5: bpy.typing.Enum1,
+    arg_3: bpy._typing.rna_enums.Enum1,
+    arg_4: set[bpy._typing.rna_enums.Enum1],
+    arg_5: bpy._typing.rna_enums.Enum1,
 ) -> module_1.submodule_1.BaseClass1:
     """function_1 description
 
@@ -20,11 +20,11 @@ def function_1(
     :param arg_2: function_1 arg_2 description
     :type arg_2: module_1.ClassA
     :param arg_3: function_1 arg_3 description
-    :type arg_3: bpy.typing.Enum1
+    :type arg_3: bpy._typing.rna_enums.Enum1
     :param arg_4: Enumerator in `rna_enum_enum1`.
-    :type arg_4: set[bpy.typing.Enum1]
+    :type arg_4: set[bpy._typing.rna_enums.Enum1]
     :param arg_5: job type in `rna_enum_enum1`.
-    :type arg_5: bpy.typing.Enum1
+    :type arg_5: bpy._typing.rna_enums.Enum1
     :return: method_1 return description
     :rtype: module_1.submodule_1.BaseClass1
     """

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.pyi
@@ -1,16 +1,16 @@
 import typing
 import collections.abc
 import typing_extensions
-import bpy.typing_enums
+import bpy.typing
 import module_1
 import module_1.submodule_1
 
 def function_1(
     arg_1: int,
     arg_2: module_1.ClassA,
-    arg_3: bpy.typing_enums.Enum1,
-    arg_4: set[bpy.typing_enums.Enum1],
-    arg_5: bpy.typing_enums.Enum1,
+    arg_3: bpy.typing.Enum1,
+    arg_4: set[bpy.typing.Enum1],
+    arg_5: bpy.typing.Enum1,
 ) -> module_1.submodule_1.BaseClass1:
     """function_1 description
 
@@ -19,11 +19,11 @@ def function_1(
     :param arg_2: function_1 arg_2 description
     :type arg_2: module_1.ClassA
     :param arg_3: function_1 arg_3 description
-    :type arg_3: bpy.typing_enums.Enum1
+    :type arg_3: bpy.typing.Enum1
     :param arg_4: Enumerator in `rna_enum_enum1`.
-    :type arg_4: set[bpy.typing_enums.Enum1]
+    :type arg_4: set[bpy.typing.Enum1]
     :param arg_5: job type in `rna_enum_enum1`.
-    :type arg_5: bpy.typing_enums.Enum1
+    :type arg_5: bpy.typing.Enum1
     :return: method_1 return description
     :rtype: module_1.submodule_1.BaseClass1
     """

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.pyi
@@ -1,16 +1,16 @@
 import typing
 import collections.abc
 import typing_extensions
-import bpy.typing
+import bpy._typing.rna_enums
 import module_1
 import module_1.submodule_1
 
 def function_1(
     arg_1: int,
     arg_2: module_1.ClassA,
-    arg_3: bpy.typing.Enum1,
-    arg_4: set[bpy.typing.Enum1],
-    arg_5: bpy.typing.Enum1,
+    arg_3: bpy._typing.rna_enums.Enum1,
+    arg_4: set[bpy._typing.rna_enums.Enum1],
+    arg_5: bpy._typing.rna_enums.Enum1,
 ) -> module_1.submodule_1.BaseClass1:
     """function_1 description
 
@@ -19,11 +19,11 @@ def function_1(
     :param arg_2: function_1 arg_2 description
     :type arg_2: module_1.ClassA
     :param arg_3: function_1 arg_3 description
-    :type arg_3: bpy.typing.Enum1
+    :type arg_3: bpy._typing.rna_enums.Enum1
     :param arg_4: Enumerator in `rna_enum_enum1`.
-    :type arg_4: set[bpy.typing.Enum1]
+    :type arg_4: set[bpy._typing.rna_enums.Enum1]
     :param arg_5: job type in `rna_enum_enum1`.
-    :type arg_5: bpy.typing.Enum1
+    :type arg_5: bpy._typing.rna_enums.Enum1
     :return: method_1 return description
     :rtype: module_1.submodule_1.BaseClass1
     """

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.pyi
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/integration_test_data/integration_test/expect/multiple/module_2/__init__.pyi
@@ -1,16 +1,16 @@
 import typing
 import collections.abc
 import typing_extensions
-import bpy.typing
+import bpy.typing_enums
 import module_1
 import module_1.submodule_1
 
 def function_1(
     arg_1: int,
     arg_2: module_1.ClassA,
-    arg_3: bpy.typing.Enum1,
-    arg_4: set[bpy.typing.Enum1],
-    arg_5: bpy.typing.Enum1,
+    arg_3: bpy.typing_enums.Enum1,
+    arg_4: set[bpy.typing_enums.Enum1],
+    arg_5: bpy.typing_enums.Enum1,
 ) -> module_1.submodule_1.BaseClass1:
     """function_1 description
 
@@ -19,11 +19,11 @@ def function_1(
     :param arg_2: function_1 arg_2 description
     :type arg_2: module_1.ClassA
     :param arg_3: function_1 arg_3 description
-    :type arg_3: bpy.typing.Enum1
+    :type arg_3: bpy.typing_enums.Enum1
     :param arg_4: Enumerator in `rna_enum_enum1`.
-    :type arg_4: set[bpy.typing.Enum1]
+    :type arg_4: set[bpy.typing_enums.Enum1]
     :param arg_5: job type in `rna_enum_enum1`.
-    :type arg_5: bpy.typing.Enum1
+    :type arg_5: bpy.typing_enums.Enum1
     :return: method_1 return description
     :rtype: module_1.submodule_1.BaseClass1
     """

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/description_dependency_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/description_dependency_transformed.xml
@@ -39,7 +39,7 @@
                             <data-type>
                                 set[
                                 <enum-ref>
-                                    bpy.typing.Example
+                                    bpy.typing_enums.Example
                                 ]
                     <argument argument_type="arg">
                         <name>
@@ -50,7 +50,7 @@
                         <data-type-list>
                             <data-type>
                                 <enum-ref>
-                                    bpy.typing.Example
+                                    bpy.typing_enums.Example
                     <argument argument_type="arg">
                         <name>
                             arg_3
@@ -61,7 +61,7 @@
                             <data-type>
                                 set[
                                 <enum-ref>
-                                    bpy.typing.Example
+                                    bpy.typing_enums.Example
                                 ]
                 <return>
                     <description>

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/description_dependency_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/description_dependency_transformed.xml
@@ -39,7 +39,7 @@
                             <data-type>
                                 set[
                                 <enum-ref>
-                                    bpy.typing.Example
+                                    bpy._typing.rna_enums.Example
                                 ]
                     <argument argument_type="arg">
                         <name>
@@ -50,7 +50,7 @@
                         <data-type-list>
                             <data-type>
                                 <enum-ref>
-                                    bpy.typing.Example
+                                    bpy._typing.rna_enums.Example
                     <argument argument_type="arg">
                         <name>
                             arg_3
@@ -61,7 +61,7 @@
                             <data-type>
                                 set[
                                 <enum-ref>
-                                    bpy.typing.Example
+                                    bpy._typing.rna_enums.Example
                                 ]
                 <return>
                     <description>

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/description_dependency_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/description_dependency_transformed.xml
@@ -39,7 +39,7 @@
                             <data-type>
                                 set[
                                 <enum-ref>
-                                    bpy.typing_enums.Example
+                                    bpy.typing.Example
                                 ]
                     <argument argument_type="arg">
                         <name>
@@ -50,7 +50,7 @@
                         <data-type-list>
                             <data-type>
                                 <enum-ref>
-                                    bpy.typing_enums.Example
+                                    bpy.typing.Example
                     <argument argument_type="arg">
                         <name>
                             arg_3
@@ -61,7 +61,7 @@
                             <data-type>
                                 set[
                                 <enum-ref>
-                                    bpy.typing_enums.Example
+                                    bpy.typing.Example
                                 ]
                 <return>
                     <description>

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
@@ -145,7 +145,7 @@
             <data-type option="never none">
                 set[
                 <enum-ref>
-                    bpy.typing_enums.Example
+                    bpy.typing.Example
                 ]
     <data>
         <name>
@@ -154,7 +154,7 @@
         <data-type-list>
             <data-type option="never none">
                 <enum-ref>
-                    bpy.typing_enums.Example
+                    bpy.typing.Example
     <data>
         <name>
             data_enumerated_constant

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
@@ -145,7 +145,7 @@
             <data-type option="never none">
                 set[
                 <enum-ref>
-                    bpy.typing.Example
+                    bpy._typing.rna_enums.Example
                 ]
     <data>
         <name>
@@ -154,7 +154,7 @@
         <data-type-list>
             <data-type option="never none">
                 <enum-ref>
-                    bpy.typing.Example
+                    bpy._typing.rna_enums.Example
     <data>
         <name>
             data_enumerated_constant

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/various_data_type_transformed.xml
@@ -145,7 +145,7 @@
             <data-type option="never none">
                 set[
                 <enum-ref>
-                    bpy.typing.Example
+                    bpy.typing_enums.Example
                 ]
     <data>
         <name>
@@ -154,7 +154,7 @@
         <data-type-list>
             <data-type option="never none">
                 <enum-ref>
-                    bpy.typing.Example
+                    bpy.typing_enums.Example
     <data>
         <name>
             data_enumerated_constant

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/rna_enum_converter_test/expect/basic_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/rna_enum_converter_test/expect/basic_transformed.xml
@@ -3,7 +3,7 @@
         basic.rst
     <module>
         <name>
-            bpy.typing
+            bpy.typing_enums
         <description>
     <enum>
         <name>

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/rna_enum_converter_test/expect/basic_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/rna_enum_converter_test/expect/basic_transformed.xml
@@ -3,7 +3,7 @@
         basic.rst
     <module>
         <name>
-            bpy.typing_enums
+            bpy.typing
         <description>
     <enum>
         <name>

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/rna_enum_converter_test/expect/basic_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/rna_enum_converter_test/expect/basic_transformed.xml
@@ -3,7 +3,7 @@
         basic.rst
     <module>
         <name>
-            bpy.typing
+            bpy._typing.rna_enums
         <description>
     <enum>
         <name>


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

- Fix #318

### Description about the pull request

Remove `from . import typing as typing` from `bpy/__init__.pyi` as it is not available in runtime.