### PR TITLE
Use _GenericType1 for bpy_prop_collection_idprop.add() return type

### DIFF
--- a/src/mods/common/analyzer/update/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/update/bpy.types.mod.rst
@@ -55,6 +55,11 @@
 
    :generic-types: _GenericType1
 
+   .. method:: add()
+
+      :rtype: _GenericType1
+      :mod-option rtype: skip-refine
+
    .. method:: values()
 
       :rtype: list[_GenericType1 | None]


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

- Follow up on #340, @Andrej730 on discord noticed that `bpy_prop_collection_idprop.add()` return type could be improved from `typing.Any` to `_GenericType1`.

### Description about the pull request

Add an update mod for the return type of  `bpy_prop_collection_idprop.add()`.