### PR TITLE
Fix typing issues

### DIFF
--- a/src/fake_bpy_module/analyzer/nodes.py
+++ b/src/fake_bpy_module/analyzer/nodes.py
@@ -127,8 +127,8 @@ class DataNode(UniqueElementNode, nodes.Part):
     @classmethod
     def create_template(
             cls: type[Self], rawsource: str = "",
-            *children: nodes.Node, **attributes: dict) -> type[Self]:
-        node = DataNode(rawsource, *children, **attributes)
+            *children: nodes.Node, **attributes: dict) -> Self:
+        node = cls(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
         node.append_child(DescriptionNode())
@@ -145,8 +145,8 @@ class AttributeNode(DataNode):
     @classmethod
     def create_template(
             cls: type[Self], rawsource: str = "",
-            *children: nodes.Node, **attributes: dict) -> type[Self]:
-        node = AttributeNode(rawsource, *children, **attributes)
+            *children: nodes.Node, **attributes: dict) -> Self:
+        node = cls(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
         node.append_child(DescriptionNode())
@@ -176,8 +176,8 @@ class ArgumentNode(UniqueElementNode, nodes.Part):
     @classmethod
     def create_template(
             cls: type[Self], rawsource: str = "",
-            *children: nodes.Node, **attributes: dict) -> type[Self]:
-        node = ArgumentNode(rawsource, *children, **attributes)
+            *children: nodes.Node, **attributes: dict) -> Self:
+        node = cls(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
         node.append_child(DescriptionNode())
@@ -195,8 +195,8 @@ class FunctionReturnNode(UniqueElementNode, nodes.Part):
     @classmethod
     def create_template(
             cls: type[Self], rawsource: str = "",
-            *children: nodes.Node, **attributes: dict) -> type[Self]:
-        node = FunctionReturnNode(rawsource, *children, **attributes)
+            *children: nodes.Node, **attributes: dict) -> Self:
+        node = cls(rawsource, *children, **attributes)
 
         node.append_child(DescriptionNode())
         node.append_child(DataTypeListNode())
@@ -215,8 +215,8 @@ class FunctionNode(UniqueElementNode, nodes.Part):
     @classmethod
     def create_template(
             cls: type[Self], rawsource: str = "",
-            *children: nodes.Node, **attributes: dict) -> type[Self]:
-        node = FunctionNode(rawsource, *children, **attributes)
+            *children: nodes.Node, **attributes: dict) -> Self:
+        node = cls(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
         node.append_child(DescriptionNode())
@@ -239,8 +239,8 @@ class BaseClassNode(UniqueElementNode, nodes.Part):
     @classmethod
     def create_template(
             cls: type[Self], rawsource: str = "",
-            *children: nodes.Node, **attributes: dict) -> type[Self]:
-        node = BaseClassNode(rawsource, *children, **attributes)
+            *children: nodes.Node, **attributes: dict) -> Self:
+        node = cls(rawsource, *children, **attributes)
 
         node.append_child(DataTypeListNode())
 
@@ -255,8 +255,8 @@ class ClassNode(UniqueElementNode, nodes.Part):
     @classmethod
     def create_template(
             cls: type[Self], rawsource: str = "",
-            *children: nodes.Node, **attributes: dict) -> type[Self]:
-        node = ClassNode(rawsource, *children, **attributes)
+            *children: nodes.Node, **attributes: dict) -> Self:
+        node = cls(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
         node.append_child(DescriptionNode())
@@ -275,8 +275,8 @@ class ModuleNode(UniqueElementNode, nodes.Part):
     @classmethod
     def create_template(
             cls: type[Self], rawsource: str = "",
-            *children: nodes.Node, **attributes: dict) -> type[Self]:
-        node = ModuleNode(rawsource, *children, **attributes)
+            *children: nodes.Node, **attributes: dict) -> Self:
+        node = cls(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
         node.append_child(DescriptionNode())
@@ -297,8 +297,8 @@ class EnumItemNode(UniqueElementNode, nodes.Part):
     @classmethod
     def create_template(
             cls: type[Self], rawsource: str = "",
-            *children: nodes.Node, **attributes: dict) -> type[Self]:
-        node = EnumItemNode(rawsource, *children, **attributes)
+            *children: nodes.Node, **attributes: dict) -> Self:
+        node = cls(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
         node.append_child(DescriptionNode())
@@ -319,8 +319,8 @@ class EnumNode(UniqueElementNode, nodes.Part):
     @classmethod
     def create_template(
             cls: type[Self], rawsource: str = "",
-            *children: nodes.Node, **attributes: dict) -> type[Self]:
-        node = EnumNode(rawsource, *children, **attributes)
+            *children: nodes.Node, **attributes: dict) -> Self:
+        node = cls(rawsource, *children, **attributes)
 
         node.append_child(NameNode())
         node.append_child(DescriptionNode())

--- a/src/fake_bpy_module/analyzer/nodes.py
+++ b/src/fake_bpy_module/analyzer/nodes.py
@@ -32,7 +32,7 @@ class UniqueElementNode(NodeBase):
     def element(self, element_type: type[T]) -> T:
         return self.elements[element_type]
 
-    def deepcopy(self) -> type[Self]:
+    def deepcopy(self) -> Self:
         new_obj = super().deepcopy()
         new_obj.elements.clear()
         for child in new_obj.children:

--- a/src/fake_bpy_module/config.py
+++ b/src/fake_bpy_module/config.py
@@ -22,11 +22,11 @@ class Configuration:
         raise NotImplementedError("Not allowed to call constructor")
 
     @classmethod
-    def __internal_new(cls: type[Self]) -> type[Self]:
+    def __internal_new(cls: type[Self]) -> Self:
         return super().__new__(cls)
 
     @classmethod
-    def get_instance(cls: type[Self]) -> type[Self]:
+    def get_instance(cls: type[Self]) -> Self:
         if not cls.__inst:
             with cls.__lock:
                 if not cls.__inst:

--- a/src/fake_bpy_module/generator/code_writer.py
+++ b/src/fake_bpy_module/generator/code_writer.py
@@ -14,7 +14,7 @@ class CodeWriterIndent:
         self._indent: int = indent
         self._append_current_indent = append_current_indent
 
-    def __enter__(self) -> type[Self]:
+    def __enter__(self) -> Self:
         cls = self.__class__
         cls.add_indent(self._indent, self._append_current_indent)
 


### PR DESCRIPTION
Otherwise e.g. it was returning type[BaseClassNode] instead BaseClassNode instance resulting in errors like `argument missing for parameter "element_type"` or `Argument of type "type[BaseClassNode]" cannot be assigned to parameter "item" of type "Node" in function "append_child"
  "type[type]" is incompatible with "type[Node]` in

https://github.com/nutti/fake-bpy-module/blob/23afc7b5b1ddca151a4e4cc04df2ebd1cfabaf7c/src/fake_bpy_module/transformer/bpy_module_tweaker.py#L195-L198

Also used `cls` instead of explicit name to avoid error `Expression of type "BaseClassNode" is incompatible with return type "Self@BaseClassNode"` near `create_template` `return`.