### PR TITLE
Fix: Use more specific dict type for ImagePreviewCollection #351

### DIFF
--- a/src/mods/common/analyzer/append/bpy.utils.preview.mod.rst
+++ b/src/mods/common/analyzer/append/bpy.utils.preview.mod.rst
@@ -4,6 +4,6 @@
 
 .. class:: ImagePreviewCollection
 
-   .. base-class:: dict
+   .. base-class:: dict[str, bpy.types.ImagePreview]
 
       :mod-option base-class: skip-refine


### PR DESCRIPTION
This PR is fiixing issues in the example snippet:
```python
import bpy
from typing import assert_type

icons = bpy.utils.previews.new()
# "assert_type" mismatch: expected "ImagePreview" but received "Unknown"
assert_type(icons["test"], bpy.types.ImagePreview)
# "assert_type" mismatch: expected "ImagePreview | None" but received "Unknown | None"
assert_type(icons.get("test"), bpy.types.ImagePreview | None)


print(type(icons).__bases__)  # (<class 'dict'>,)
```