### PR TITLE
Fix: Add Python 3.11 support for building and testing

### DIFF
--- a/docs/generate_modules.md
+++ b/docs/generate_modules.md
@@ -13,8 +13,8 @@ You can choose the method to generate modules.
 
 ### Python Version
 
-The generating script can be run on Python >= 3.12.
-Check your Python version is >= 3.12.
+The generating script can be run on Python >= 3.11.
+Check your Python version is >= 3.11.
 
 ### Install requirement packages
 
@@ -126,7 +126,7 @@ environment variable.
 
 <!-- markdownlint-disable MD013 -->
 ```bash
-PYTHON_BIN=/path/to/python3.12 bash gen_module.sh <source-dir> <blender-dir> <target> <branch/tag/commit> <target-version> <output-dir> [<mod-version>]
+PYTHON_BIN=/path/to/python3.11 bash gen_module.sh <source-dir> <blender-dir> <target> <branch/tag/commit> <target-version> <output-dir> [<mod-version>]
 ```
 <!-- markdownlint-enable MD013 -->
 

--- a/src/fake_bpy_module/generator/writers.py
+++ b/src/fake_bpy_module/generator/writers.py
@@ -605,8 +605,9 @@ class PyCodeWriterBase(BaseWriter):
             else:
                 enum_item_strs.append(f"'{enum_item_name}',")
 
+        enum_item_strs_lines = "\n".join(enum_item_strs)
         wt.addln(f"type {enum_name} = typing.Literal[\n"
-                 f"{'\n'.join(enum_item_strs)}\n]")
+                 f"{enum_item_strs_lines}\n]")
 
     def write(self, filename: str, document: nodes.document,
               style_config: str = 'ruff') -> None:

--- a/src/gen_module.sh
+++ b/src/gen_module.sh
@@ -63,8 +63,8 @@ python_bin=$(command -v "${PYTHON_BIN}")
 
 echo "Checking if Python version meets the requirements ..."
 IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
-if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 12 ]]; then
-    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.12 or higher."
+if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 11 ]]; then
+    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.11 or higher."
     exit 1
 fi
 

--- a/tests/pylint_cycles.sh
+++ b/tests/pylint_cycles.sh
@@ -107,8 +107,8 @@ python_bin=$(command -v "${PYTHON_BIN}")
 
 # check if python version meets our requirements
 IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
-if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 12 ]]; then
-    echo "Error: Unsupported Python version \"${python_version[0]}.${python_version[1]}\". Requiring Python 3.12 or higher."
+if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 11 ]]; then
+    echo "Error: Unsupported Python version \"${python_version[0]}.${python_version[1]}\". Requiring Python 3.11 or higher."
     exit 1
 fi
 

--- a/tests/run_pre_tests.sh
+++ b/tests/run_pre_tests.sh
@@ -28,8 +28,8 @@ python_bin=$(command -v "${PYTHON_BIN}")
 
 # check if python version meets our requirements
 IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
-if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 12 ]]; then
-    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.12 or higher."
+if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 11 ]]; then
+    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.11 or higher."
     exit 1
 fi
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -23,8 +23,8 @@ python_bin=$(command -v "${PYTHON_BIN}")
 
 # check if python version meets our requirements
 IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
-if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 12 ]]; then
-    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.12 or higher."
+if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 11 ]]; then
+    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.11 or higher."
     exit 1
 fi
 

--- a/tools/pip_package/build_pip_package.sh
+++ b/tools/pip_package/build_pip_package.sh
@@ -83,8 +83,8 @@ python_bin=$(command -v "${PYTHON_BIN}")
 
 # check if python version meets our requirements
 IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
-if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 12 ]]; then
-    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.12 or higher."
+if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 11 ]]; then
+    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.11 or higher."
     exit 1
 fi
 


### PR DESCRIPTION
Added support for Python 3.11 as it probably makes sense to support as it is the current Blender main Python version (at least it's the main reason why I'm stuck on Python 3.11).

I believe, previously it was changed to Python 3.12 to support new `type` syntax when entire `fake-bpy-module` was moved to 3.12 but it was reverted and `type` syntax is supported either way since it's only used in '.pyi' files.

Ping @JonathanPlasse just in case.