### PR TITLE
Update: add `__iter__` for IDPropertyGroupView classes

### DIFF
--- a/src/mods/common/analyzer/append/idprop.types.mod.rst
+++ b/src/mods/common/analyzer/append/idprop.types.mod.rst
@@ -1,0 +1,22 @@
+.. mod-type:: append
+
+.. module:: idprop.types
+
+
+.. class:: idprop.types.IDPropertyGroupViewItems
+
+   .. base-class:: collections.abc.Iterable[tuple[str, typing.Any]]
+
+      :mod-option base-class: skip-refine
+
+.. class:: idprop.types.IDPropertyGroupViewKeys
+
+   .. base-class:: collections.abc.Iterable[str]
+
+      :mod-option base-class: skip-refine
+
+.. class:: idprop.types.IDPropertyGroupViewValues
+
+   .. base-class:: collections.abc.Iterable[typing.Any]
+
+      :mod-option base-class: skip-refine


### PR DESCRIPTION
PR solves issues with an example below:
```python
import bpy

class MyPropertyGroup(bpy.types.PropertyGroup):
    custom_1: bpy.props.FloatProperty(name="My Float")
    custom_2: bpy.props.IntProperty(name="My Int")

bpy.utils.register_class(MyPropertyGroup)

bpy.types.Object.my_prop_grp = bpy.props.PointerProperty(type=MyPropertyGroup)

props: MyPropertyGroup = bpy.data.objects[0].my_prop_grp
props.custom_1 = 22.0
print(a:=list(props.keys()))
print(b:=list(props.values()))
print(c:=list(props.items()))
print(c:=list(props.items()))
```

Diff for fake bpy modules after PR:
```diff
diff --git a/build_files/idprop/types/__init__.pyi b/build_files/idprop/types/__init__.pyi
index 7ab9575..557abce 100644
--- a/build_files/idprop/types/__init__.pyi
+++ b/build_files/idprop/types/__init__.pyi
@@ -55,6 +55,6 @@ class IDPropertyGroup:
 class IDPropertyGroupIterItems: ...
 class IDPropertyGroupIterKeys: ...
 class IDPropertyGroupIterValues: ...
-class IDPropertyGroupViewItems: ...
-class IDPropertyGroupViewKeys: ...
-class IDPropertyGroupViewValues: ...
+class IDPropertyGroupViewItems(collections.abc.Iterable[tuple[str, typing.Any]]): ...
+class IDPropertyGroupViewKeys(collections.abc.Iterable[str]): ...
+class IDPropertyGroupViewValues(collections.abc.Iterable[typing.Any]): ...
```

<!-- markdownlint-disable MD036 MD041 -->