### PR TITLE
Update test setup to use modern unittest API

### DIFF
--- a/tests/python/fake_bpy_module_test/run_tests.py
+++ b/tests/python/fake_bpy_module_test/run_tests.py
@@ -69,7 +69,7 @@ def main() -> None:
 
     suite = unittest.TestSuite()
     for case in test_cases:
-        suite.addTest(unittest.makeSuite(case))
+        suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(case))
     ret = unittest.TextTestRunner().run(suite).wasSuccessful()
     sys.exit(not ret)
 

--- a/tests/python/import_module_test/run_tests.py
+++ b/tests/python/import_module_test/run_tests.py
@@ -102,7 +102,7 @@ def generate_tests(config: ImportModuleTestConfig) -> list:
 def run_tests(test_cases: list) -> bool:
     suite = unittest.TestSuite()
     for case in test_cases:
-        suite.addTest(unittest.makeSuite(case))
+        suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(case))
     return unittest.TextTestRunner().run(suite).wasSuccessful()
 
 


### PR DESCRIPTION
### Purpose of the pull request

Fix Deprecation Warnings

### Description about the pull request

Replaces deprecated `unittest.makeSuite()` with `unittest.defaultTestLoader.loadTestsFromTestCase()` in test files to resolve Python 3.13+ compatibility warnings which you can find in the [CI logs](https://github.com/nutti/fake-bpy-module/actions/runs/14770894059/job/41470653842#step:18:699):
```python
 /home/runner/work/fake-bpy-module/fake-bpy-module/tests/python/fake_bpy_module_test/run_tests.py:72: DeprecationWarning: unittest.makeSuite() is deprecated and will be removed in Python 3.13. Please use unittest.TestLoader.loadTestsFromTestCase() instead.
```

### Additional comments** [Optional]
