### PR TITLE
Update: Add generics to bpy.props callables to avoid false positives

### DIFF
--- a/src/fake_bpy_module/config.py
+++ b/src/fake_bpy_module/config.py
@@ -11,7 +11,7 @@ class Configuration:
     style_format: str = "ruff"
     target: str = "blender"
     target_version: str = None
-    mod_version: str = None
+    mod_version: str | None = None
     output_format: str = "pyi"
 
     # pylint: disable=W0201
@@ -105,7 +105,7 @@ def get_target_version() -> str:
     return inst.target_version
 
 
-def get_mod_version() -> str:
+def get_mod_version() -> str | None:
     inst = Configuration.get_instance()
     return inst.mod_version
 

--- a/src/fake_bpy_module/utils.py
+++ b/src/fake_bpy_module/utils.py
@@ -111,3 +111,10 @@ def split_string_by_comma(
 def split_string_by_bar(
         line: str, workaround_special_brace_case: bool = True) -> list:
     return split_string_by(line, "|", workaround_special_brace_case)
+
+
+def to_version_int(v: str) -> list[int]:
+    if v == "latest":
+        # Make "latest" less special.
+        return [999, 999]
+    return [int(i) for i in v.split(".")]

--- a/src/gen.py
+++ b/src/gen.py
@@ -131,12 +131,33 @@ def collect_files() -> tuple[list[str], list[str]]:
         str(p.absolute())
         for p in Path(f"{MOD_FILES_DIR}/mods/common").rglob("*.mod.rst")
     ]
-    if target == "blender" and mod_version in ["2.78", "2.79"]:
-        mod_files += [
-            str(p.absolute())
-            for p in Path(f"{MOD_FILES_DIR}/mods/{target}/{mod_version}")
-            .rglob("*.mod.rst")
+
+    # Collect version specific mod files.
+    if target == "blender":
+        applicable_mod_versions: list[str] = []
+        # Collect single-version mods.
+        single_version_mods = ["2.78", "2.79"]
+        if mod_version in single_version_mods:
+            applicable_mod_versions.append(mod_version)
+
+        # Collect multi-version mods.
+        multiversion_mods = ["2.79", "3.3"]
+
+        applicable_mod_versions += [
+            f"{mv}+"
+            for mv in multiversion_mods
+            if mod_version is None
+            or fbm.utils.to_version_int(mod_version)
+            >= fbm.utils.to_version_int(mv)
         ]
+
+        for mod_version_ in applicable_mod_versions:
+            mod_files += [
+                str(p.absolute())
+                for p in Path(f"{MOD_FILES_DIR}/mods/{target}/{mod_version_}")
+                .rglob("*.mod.rst")
+            ]
+
     # Remove unnecessary mod files.
     mod_files = set(mod_files)
     if target == "blender":

--- a/src/mods/blender/2.79+/analyzer/update/bpy.props.mod.rst
+++ b/src/mods/blender/2.79+/analyzer/update/bpy.props.mod.rst
@@ -1,0 +1,9 @@
+.. mod-type:: update
+
+.. module:: bpy.props
+
+.. `prop` argument was introduced in Blender 2.79
+.. function:: PointerProperty(poll)
+
+   :type poll: collections.abc.Callable[[_GenericType1, _GenericType2], bool] | None
+   :mod-option arg poll: skip-refine

--- a/src/mods/blender/3.3+/analyzer/update/bpy.props.mod.rst
+++ b/src/mods/blender/3.3+/analyzer/update/bpy.props.mod.rst
@@ -1,0 +1,9 @@
+.. mod-type:: update
+
+.. module:: bpy.props
+
+.. `search` argument was introduced in Blender 3.3.
+.. function:: StringProperty(search)
+
+   :type search: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`, str], collections.abc.Iterable[str | tuple[str, str]]] | None
+   :mod-option arg search: skip-refine

--- a/src/mods/common/analyzer/update/bpy.props.mod.rst
+++ b/src/mods/common/analyzer/update/bpy.props.mod.rst
@@ -96,17 +96,14 @@
    :type set: collections.abc.Callable[[_GenericType1, collections.abc.Sequence[int]], None] | None
    :mod-option arg set: skip-refine
 
-.. function:: PointerProperty(poll, update)
+.. function:: PointerProperty(update)
 
    :generic-types: _GenericType1: bpy.types.bpy_struct, _GenericType2: bpy.types.ID
-
-   :type poll: collections.abc.Callable[[_GenericType1, _GenericType2], bool] | None
-   :mod-option arg poll: skip-refine
 
    :type update: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`], None] | None
    :mod-option arg update: skip-refine
 
-.. function:: StringProperty(update, get, set, search)
+.. function:: StringProperty(update, get, set)
 
    :generic-types: _GenericType1: bpy.types.bpy_struct
 
@@ -118,6 +115,3 @@
 
    :type set: collections.abc.Callable[[_GenericType1, str], None] | None
    :mod-option arg set: skip-refine
-
-   :type search: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`, str], collections.abc.Iterable[str | tuple[str, str]]] | None
-   :mod-option arg search: skip-refine

--- a/src/mods/common/analyzer/update/bpy.props.mod.rst
+++ b/src/mods/common/analyzer/update/bpy.props.mod.rst
@@ -2,7 +2,122 @@
 
 .. module:: bpy.props
 
-.. function:: EnumProperty(items)
+.. function:: BoolProperty(update, get, set)
 
-   :type items: collections.abc.Iterable[tuple[str, str, str] | tuple[str, str, str, int] | tuple[str, str, str, str, int] | None] | collections.abc.Callable[[typing.Any, :class:`bpy.types.Context` | None], collections.abc.Iterable[tuple[str, str, str] | tuple[str, str, str, int] | tuple[str, str, str, str, int] | None]]
+   :generic-types: _GenericType1: bpy.types.bpy_struct
+
+   :type update: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`], None] | None
+   :mod-option arg update: skip-refine
+
+   :type get: collections.abc.Callable[[_GenericType1], bool] | None
+   :mod-option arg get: skip-refine
+
+   :type set: collections.abc.Callable[[_GenericType1, bool], None] | None
+   :mod-option arg set: skip-refine
+
+.. function:: BoolVectorProperty(update, get, set)
+
+   :generic-types: _GenericType1: bpy.types.bpy_struct
+
+   :type update: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`], None] | None
+   :mod-option arg update: skip-refine
+
+   :type get: collections.abc.Callable[[_GenericType1], collections.abc.Sequence[bool]] | None
+   :mod-option arg get: skip-refine
+
+   :type set: collections.abc.Callable[[_GenericType1, collections.abc.Sequence[bool]], None] | None
+   :mod-option arg set: skip-refine
+
+.. function:: EnumProperty(items, update, get, set)
+
+   :generic-types: _GenericType1: bpy.types.bpy_struct
+
+   :type items: collections.abc.Iterable[tuple[str, str, str] | tuple[str, str, str, int] | tuple[str, str, str, str, int] | None] | collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context` | None], collections.abc.Iterable[tuple[str, str, str] | tuple[str, str, str, int] | tuple[str, str, str, str, int] | None]]
    :mod-option arg items: skip-refine
+
+   :type update: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`], None] | None
+   :mod-option arg update: skip-refine
+
+   :type get: collections.abc.Callable[[_GenericType1], int] | None
+   :mod-option arg get: skip-refine
+
+   :type set: collections.abc.Callable[[_GenericType1, int], None] | None
+   :mod-option arg set: skip-refine
+
+.. function:: FloatProperty(update, get, set)
+
+   :generic-types: _GenericType1: bpy.types.bpy_struct
+
+   :type update: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`], None] | None
+   :mod-option arg update: skip-refine
+
+   :type get: collections.abc.Callable[[_GenericType1], float] | None
+   :mod-option arg get: skip-refine
+
+   :type set: collections.abc.Callable[[_GenericType1, float], None] | None
+   :mod-option arg set: skip-refine
+
+.. function:: FloatVectorProperty(update, get, set)
+
+   :generic-types: _GenericType1: bpy.types.bpy_struct
+
+   :type update: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`], None] | None
+   :mod-option arg update: skip-refine
+
+   :type get: collections.abc.Callable[[_GenericType1], collections.abc.Sequence[float]] | None
+   :mod-option arg get: skip-refine
+
+   :type set: collections.abc.Callable[[_GenericType1, collections.abc.Sequence[float]], None] | None
+   :mod-option arg set: skip-refine
+
+.. function:: IntProperty(update, get, set)
+
+   :generic-types: _GenericType1: bpy.types.bpy_struct
+
+   :type update: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`], None] | None
+   :mod-option arg update: skip-refine
+
+   :type get: collections.abc.Callable[[_GenericType1], int] | None
+   :mod-option arg get: skip-refine
+
+   :type set: collections.abc.Callable[[_GenericType1, int], None] | None
+   :mod-option arg set: skip-refine
+
+.. function:: IntVectorProperty(update, get, set)
+
+   :generic-types: _GenericType1: bpy.types.bpy_struct
+
+   :type update: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`], None] | None
+   :mod-option arg update: skip-refine
+
+   :type get: collections.abc.Callable[[_GenericType1], collections.abc.Sequence[int]] | None
+   :mod-option arg get: skip-refine
+
+   :type set: collections.abc.Callable[[_GenericType1, collections.abc.Sequence[int]], None] | None
+   :mod-option arg set: skip-refine
+
+.. function:: PointerProperty(poll, update)
+
+   :generic-types: _GenericType1: bpy.types.bpy_struct, _GenericType2: bpy.types.ID
+
+   :type poll: collections.abc.Callable[[_GenericType1, _GenericType2], bool] | None
+   :mod-option arg poll: skip-refine
+
+   :type update: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`], None] | None
+   :mod-option arg update: skip-refine
+
+.. function:: StringProperty(update, get, set, search)
+
+   :generic-types: _GenericType1: bpy.types.bpy_struct
+
+   :type update: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`], None] | None
+   :mod-option arg update: skip-refine
+
+   :type get: collections.abc.Callable[[_GenericType1], str] | None
+   :mod-option arg get: skip-refine
+
+   :type set: collections.abc.Callable[[_GenericType1, str], None] | None
+   :mod-option arg set: skip-refine
+
+   :type search: collections.abc.Callable[[_GenericType1, :class:`bpy.types.Context`, str], collections.abc.Iterable[str | tuple[str, str]]] | None
+   :mod-option arg search: skip-refine


### PR DESCRIPTION
Fixes #361

Originally I thought that `Any` would work for this, but then we would lose type information completely.

Implementing here an idea from @JonathanPlasse to use bounded generics to make callables kind of covariant instead of contravariant where we need it.

Was manually patching my `bpy.props` before and testing it for a week now - seems to cover all cases.

```python
from typing import Callable


class A:
    pass


class B(A):
    pass


def f(v: B) -> None:
    pass


def g_bad(v: Callable[[A], None]) -> None:
    pass


def g_good[T: A](v: Callable[[T], None]) -> None:
    pass


g_bad(f)
g_good(f)
```