### PR TITLE
Add: Return types for ImportHelper and ExportHelper methods

### DIFF
--- a/src/mods/common/analyzer/append/bpy_extras.io_utils.mod.rst
+++ b/src/mods/common/analyzer/append/bpy_extras.io_utils.mod.rst
@@ -1,0 +1,27 @@
+.. mod-type:: append
+
+.. module:: bpy_extras.io_utils
+
+.. class:: ExportHelper
+
+   .. method:: invoke(context, _event)
+
+      :rtype: enum set in :ref:`rna_enum_operator_return_items`
+
+   .. method:: check(_context)
+
+      :rtype: bool
+
+.. class:: ImportHelper
+
+   .. method:: invoke(context, _event)
+
+      :rtype: enum set in :ref:`rna_enum_operator_return_items`
+
+   .. method:: invoke_popup(context, confirm_text="")
+
+      :rtype: enum set in :ref:`rna_enum_operator_return_items`
+
+   .. method:: check(_context)
+
+      :rtype: bool


### PR DESCRIPTION
<!-- markdownlint-disable MD036 MD041 -->

### Purpose of the pull request

This PR adds return types for the `ExportHelper` and `ImportHelper` mixin class methods, to prevent errors such as `reportIncompatibleMethodOverride` .

### Description about the pull request

Creates an append mod file for `bpy_extras.io_utils` to define the return types.

### Additional comments**

I have also raised a PR for this upstream in case that is more appropriate (https://projects.blender.org/blender/blender/pulls/146271).