### PR TITLE
Fix: Support new private modules in Blender 5.0 #399

### DIFF
--- a/src/gen_modfile/gen_external_modules_modfile.py
+++ b/src/gen_modfile/gen_external_modules_modfile.py
@@ -72,7 +72,6 @@ IGNORE_DOC_REGEX_LIST = {
     re.compile(r"^_bl_i18n_utils.utils.I18nMessages.find_best_messages_matches$"),
     re.compile(r"^_bl_i18n_utils.utils.I18nMessages.merge$"),
     re.compile(r"^_bl_i18n_utils.utils.I18nMessages.parse_messages_from_po$"),
-    #
     re.compile(r"^bpy_extras.wm_utils.progress_report.ProgressReport$"),
     re.compile(r"^bpy_types.RNAMeta$"),
     re.compile(r"^bpy_types.RNAMetaPropGroup$"),


### PR DESCRIPTION
Doesn't solve build problems with Blender 5.0 completely, but resolves issues with some modules moved to `_` prefix (e.g. `bl_i18n_utils` -> `_bl_i18n_utils`).