### PR TITLE
Update: add support for `important` nodes

### DIFF
--- a/src/fake_bpy_module/generator/translator.py
+++ b/src/fake_bpy_module/generator/translator.py
@@ -71,7 +71,7 @@ class CodeDocumentNodeTranslator(nodes.SparseNodeVisitor):
         if len(self.status_stack) >= 1:
             status = self.status_stack[-1]
             if status.kind in ('BULLET_LIST', 'ENUMERATED_LIST', 'NOTE',
-                               'WARNING', 'BLOCK_QUOTE'):
+                               'IMPORTANT', 'WARNING', 'BLOCK_QUOTE'):
                 new_line_num = 1
         else:
             new_line_num = 2
@@ -296,6 +296,16 @@ class CodeDocumentNodeTranslator(nodes.SparseNodeVisitor):
     def depart_note(self, _: nodes.note) -> None:
         status = self.status_stack.pop()
         assert status.kind == 'NOTE'
+
+        self.doc_writer.new_line(1)
+
+    def visit_important(self, _: nodes.important) -> None:
+        self.status_stack.append(Status('IMPORTANT'))
+        self.doc_writer.addln("[IMPORTANT]")
+
+    def depart_important(self, _: nodes.important) -> None:
+        status = self.status_stack.pop()
+        assert status.kind == 'IMPORTANT'
 
         self.doc_writer.new_line(1)
 

--- a/src/fake_bpy_module/transformer/rst_specific_node_cleaner.py
+++ b/src/fake_bpy_module/transformer/rst_specific_node_cleaner.py
@@ -30,7 +30,7 @@ class RstSpecificNodeCleaner(TransformerBase):
                     nodes.enumerated_list | nodes.definition_list |
                     nodes.block_quote | nodes.line_block | nodes.literal_block |
                     nodes.section | nodes.field_list | nodes.note |
-                    nodes.warning | nodes.target | CodeNode):
+                    nodes.important | nodes.warning | nodes.target | CodeNode):
                 code_doc_node = CodeDocumentNode()
                 self._replace(node, code_doc_node)
                 append_child(code_doc_node, node)

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/code_document_node_translator_test/expect/basic/basic.py
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/code_document_node_translator_test/expect/basic/basic.py
@@ -40,6 +40,9 @@ Function: function_ref, Data: data_ref, Const: const_ref
 [NOTE]
 Note Contents
 
+[IMPORTANT]
+Important Contents
+
 [WARNING]
 Warning Contents
 

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/code_document_node_translator_test/expect/basic/basic.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/code_document_node_translator_test/expect/basic/basic.xml
@@ -120,6 +120,9 @@
     <note>
         <paragraph>
             Note Contents
+    <important>
+        <paragraph>
+            Important Contents
     <warning>
         <paragraph>
             Warning Contents

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/code_document_node_translator_test/expect/basic/basic_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/code_document_node_translator_test/expect/basic/basic_transformed.xml
@@ -121,6 +121,9 @@
         <note>
             <paragraph>
                 Note Contents
+        <important>
+            <paragraph>
+                Important Contents
         <warning>
             <paragraph>
                 Warning Contents

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/code_document_node_translator_test/input/basic/basic.rst
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/generator_test_data/code_document_node_translator_test/input/basic/basic.rst
@@ -53,6 +53,10 @@ Function: :func:`function_ref`, Data: :data:`data_ref`, Const: :const:`const_ref
 
    Note Contents
 
+.. important::
+
+   Important Contents
+
 .. warning::
 
    Warning Contents


### PR DESCRIPTION
Using the same handling we have for `note` nodes.

Resolves one issue from #399

Example issue - https://github.com/nutti/fake-bpy-module/issues/399#issuecomment-3477977054