### PR TITLE
Update: Add support for `Literal` types

### DIFF
--- a/src/fake_bpy_module/transformer/data_type_refiner.py
+++ b/src/fake_bpy_module/transformer/data_type_refiner.py
@@ -85,6 +85,7 @@ _REGEX_DATA_TYPE_OPTION_END_WITH_NONE = re.compile(r"or None$")
 _REGEX_DATA_TYPE_OPTION_OPTIONAL = re.compile(r"(^|^An |\()[oO]ptional(\s|\))")
 _REGEX_DATA_TYPE_STARTS_WITH_COLLECTION = re.compile(r"^(list|tuple|dict)")
 _REGEX_DATA_TYPE_MODIFIER_TYPES = re.compile(r"^(Iterable|Sequence|Callable|list|dict|tuple|type)?\[(.+)\]$")  # noqa: E501
+_REGEX_DATA_TYPE_LITERALS_TYPE = re.compile(r"^Literal\[(.+)\]$")
 _REGEX_DATA_TYPE_START_AND_END_WITH_PARENTHESES = re.compile(r"^\((.+)\)$")
 
 REGEX_SPLIT_OR = re.compile(r" \| | or |,")
@@ -768,6 +769,12 @@ class DataTypeRefiner(TransformerBase):
             modifier = pydoc_to_typing_annotation.get(modifier, modifier)
 
             return parse_multiple_data_type_elements(m.group(2), modifier)
+
+        if m := _REGEX_DATA_TYPE_LITERALS_TYPE.match(dtype_str):
+            new_dtype_node = DataTypeNode()
+            text = nodes.Text(f"typing.Literal[{m.group(1)}]")
+            append_child(new_dtype_node, text)
+            return [new_dtype_node]
 
         # Ex. string, default "", -> string
         if m := REGEX_MATCH_DATA_TYPE_WITH_DEFAULT.match(dtype_str):

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/special_data_type.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/special_data_type.xml
@@ -58,6 +58,13 @@
                 Callable[[float, int], tuple[float, int]]
     <data>
         <name>
+            data_python_typing_syntax_7
+        <description>
+        <data-type-list>
+            <data-type>
+                Literal["OPTION_1", "OPTION_2", "OPTION_3"]
+    <data>
+        <name>
             data_multiple_lines
         <description>
         <data-type-list>

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/special_data_type_transformed.xml
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/expect/special_data_type_transformed.xml
@@ -84,6 +84,13 @@
                 ]
     <data>
         <name>
+            data_python_typing_syntax_7
+        <description>
+        <data-type-list>
+            <data-type option="never none">
+                typing.Literal["OPTION_1", "OPTION_2", "OPTION_3"]
+    <data>
+        <name>
             data_multiple_lines
         <description>
         <data-type-list>

--- a/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/input/special_data_type.rst
+++ b/tests/python/fake_bpy_module_test/fake_bpy_module_test/transformer_test_data/data_type_refiner_test/input/special_data_type.rst
@@ -24,6 +24,10 @@
 
    :type: Callable[[float, int], tuple[float, int]]
 
+.. data:: data_python_typing_syntax_7
+
+   :type: Literal["OPTION_1", "OPTION_2", "OPTION_3"]
+
 .. data:: data_multiple_lines
 
    :type: type[


### PR DESCRIPTION
Support `Literal[A,B,C]` kind of types that started to be used in Blender codebase around Blender 5.0.

Diff for fake bpy module after this PR:
```diff
diff --git a/build_files/bmesh/types/__init__.pyi b/build_files/bmesh/types/__init__.pyi
index a641bb5..f19d629 100644
--- a/build_files/bmesh/types/__init__.pyi
+++ b/build_files/bmesh/types/__init__.pyi
@@ -1631,7 +1631,9 @@ class BMesh:
         loop_verts: collections.abc.Iterable[BMLoop] = (),
         loop_edges: collections.abc.Iterable[BMLoop] = (),
         faces: collections.abc.Iterable[BMFace] = (),
-        sticky_select_mode="SHARED_LOCATION",
+        sticky_select_mode: typing.Literal[
+            "SHARED_LOCATION", "DISABLED", "SHARED_VERTEX"
+        ] = "SHARED_LOCATION",
     ) -> None:
         """Set the UV selection state for loop-vertices, loop-edges & faces.This is a close equivalent to selecting in the UV editor.
 
@@ -1644,6 +1646,7 @@ class BMesh:
         :param faces: Faces to operate on.
         :type faces: collections.abc.Iterable[BMFace]
         :param sticky_select_mode: See UV_STICKY_SELECT_MODE_REF.
+        :type sticky_select_mode: typing.Literal['SHARED_LOCATION', 'DISABLED', 'SHARED_VERTEX']
         """
 
     def uv_select_foreach_set_from_mesh(
@@ -1654,7 +1657,9 @@ class BMesh:
         verts: collections.abc.Iterable[BMVert] = (),
         edges: collections.abc.Iterable[BMEdge] = (),
         faces: collections.abc.Iterable[BMFace] = (),
-        sticky_select_mode="SHARED_LOCATION",
+        sticky_select_mode: typing.Literal[
+            "SHARED_LOCATION", "DISABLED", "SHARED_VERTEX"
+        ] = "SHARED_LOCATION",
     ) -> None:
         """Select or de-select mesh elements, updating the UV selection.An equivalent to selecting from the 3D viewport for selection operations that support maintaining a synchronized UV selection.
 
@@ -1667,12 +1672,20 @@ class BMesh:
         :param faces: Faces to operate on.
         :type faces: collections.abc.Iterable[BMFace]
         :param sticky_select_mode: See UV_STICKY_SELECT_MODE_REF.
+        :type sticky_select_mode: typing.Literal['SHARED_LOCATION', 'DISABLED', 'SHARED_VERTEX']
         """
 
-    def uv_select_sync_from_mesh(self, *, sticky_select_mode="SHARED_LOCATION") -> None:
+    def uv_select_sync_from_mesh(
+        self,
+        *,
+        sticky_select_mode: typing.Literal[
+            "SHARED_LOCATION", "DISABLED", "SHARED_VERTEX"
+        ] = "SHARED_LOCATION",
+    ) -> None:
         """Sync selection from mesh to UVs.
 
         :param sticky_select_mode: Behavior when flushing from the mesh to UV selection UV_STICKY_SELECT_MODE_REF. This should only be used when preparing to create a UV selection.
+        :type sticky_select_mode: typing.Literal['SHARED_LOCATION', 'DISABLED', 'SHARED_VERTEX']
         """
 
     def uv_select_sync_to_mesh(self) -> None:
diff --git a/build_files/mathutils/__init__.pyi b/build_files/mathutils/__init__.pyi
index e26d5f9..2d9acc4 100644
--- a/build_files/mathutils/__init__.pyi
+++ b/build_files/mathutils/__init__.pyi
@@ -409,8 +409,11 @@ class Euler:
     :type: bool
     """
 
-    order: typing.Any
-    """ Euler rotation order."""
+    order: typing.Literal["XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"]
+    """ Euler rotation order.
+
+    :type: typing.Literal['XYZ', 'XZY', 'YXZ', 'YZX', 'ZXY', 'ZYX']
+    """
 
     owner: typing.Any
     """ The item this is wrapping or None  (read-only)."""
@@ -476,7 +479,7 @@ class Euler:
 
     def rotate_axis(
         self,
-        axis,
+        axis: typing.Literal["X", "Y", "Z"],
         angle: float,
         /,
     ) -> None:
@@ -484,6 +487,7 @@ class Euler:
         (no 720 degree pitches).
 
                 :param axis: An axis string.
+                :type axis: typing.Literal['X', 'Y', 'Z']
                 :param angle: angle in radians.
                 :type angle: float
         """
@@ -704,7 +708,9 @@ class Matrix:
     @classmethod
     def OrthoProjection(
         cls,
-        axis: Vector | collections.abc.Sequence[float],
+        axis: Vector
+        | collections.abc.Sequence[float]
+        | typing.Literal["X", "Y", "XY", "XZ", "YZ"],
         size: int,
         /,
     ) -> typing_extensions.Self:
@@ -713,7 +719,7 @@ class Matrix:
                 :param axis: An axis string,
         where a single axis is for a 2D matrix.
         Or a vector for an arbitrary axis
-                :type axis: Vector | collections.abc.Sequence[float]
+                :type axis: Vector | collections.abc.Sequence[float] | typing.Literal['X', 'Y', 'XY', 'XZ', 'YZ']
                 :param size: The size of the projection matrix to construct [2, 4].
                 :type size: int
                 :return: A new projection matrix.
@@ -725,7 +731,10 @@ class Matrix:
         cls,
         angle: float,
         size: int,
-        axis: Vector | collections.abc.Sequence[float] | None = [],
+        axis: Vector
+        | collections.abc.Sequence[float]
+        | typing.Literal["X", "Y", "Z"]
+        | None = [],
         /,
     ) -> typing_extensions.Self:
         """Create a matrix representing a rotation.
@@ -736,7 +745,7 @@ class Matrix:
                 :type size: int
                 :param axis: an axis string or a 3D Vector Object
         (optional when size is 2).
-                :type axis: Vector | collections.abc.Sequence[float] | None
+                :type axis: Vector | collections.abc.Sequence[float] | typing.Literal['X', 'Y', 'Z'] | None
                 :return: A new rotation matrix.
                 :rtype: typing_extensions.Self
         """
@@ -764,7 +773,7 @@ class Matrix:
     @classmethod
     def Shear(
         cls,
-        plane,
+        plane: typing.Literal["X", "Y", "XY", "XZ", "YZ"],
         size: int,
         factor: collections.abc.Sequence[float] | float,
         /,
@@ -773,6 +782,7 @@ class Matrix:
 
                 :param plane: An axis string,
         where a single axis is for a 2D matrix only.
+                :type plane: typing.Literal['X', 'Y', 'XY', 'XZ', 'YZ']
                 :param size: The size of the shear matrix to construct [2, 4].
                 :type size: int
                 :param factor: The factor of shear to apply. For a 2 size matrix use a single float. For a 3 or 4 size matrix pass a pair of floats corresponding with the plane axis.
@@ -1399,13 +1409,14 @@ class Quaternion:
 
     def to_euler(
         self,
-        order="XYZ",
+        order: typing.Literal["XYZ", "XZY", "YXZ", "YZX", "ZXY", "ZYX"] = "XYZ",
         euler_compat: Euler | collections.abc.Sequence[float] | None = None,
         /,
     ) -> Euler:
         """Return Euler representation of the quaternion.
 
                 :param order: Rotation order.
+                :type order: typing.Literal['XYZ', 'XZY', 'YXZ', 'YZX', 'ZXY', 'ZYX']
                 :param euler_compat: Optional euler argument the new euler will be made
         compatible with (no axis flipping between them).
         Useful for converting a series of matrices to animation curves.
@@ -1430,13 +1441,14 @@ class Quaternion:
 
     def to_swing_twist(
         self,
-        axis,
+        axis: typing.Literal["X", "Y", "Z"],
         /,
     ) -> tuple[Quaternion, float]:
         """Split the rotation into a swing quaternion with the specified
         axis fixed at zero, and the remaining twist rotation angle.
 
                 :param axis: Twist axis as a string.
+                :type axis: typing.Literal['X', 'Y', 'Z']
                 :return: Swing, twist angle.
                 :rtype: tuple[Quaternion, float]
         """
@@ -4006,14 +4018,16 @@ class Vector:
 
     def to_track_quat(
         self,
-        track="Z",
-        up="Y",
+        track: typing.Literal["-", "X", "Y", "Z", "-X", "-Y", "-Z"] = "Z",
+        up: typing.Literal["X", "Y", "Z"] = "Y",
         /,
     ) -> Quaternion:
         """Return a quaternion rotation from the vector and the track and up axis.
 
         :param track: Track axis string.
+        :type track: typing.Literal['-', 'X', 'Y', 'Z', '-X', '-Y', '-Z']
         :param up: Up axis string.
+        :type up: typing.Literal['X', 'Y', 'Z']
         :return: rotation from the vector and the track and up axis.
         :rtype: Quaternion
         """
```