### PR TITLE
Fix: incorrect `list` types using redundant `...` arg

### DIFF
--- a/src/mods/common/analyzer/append/bmesh.types.mod.rst
+++ b/src/mods/common/analyzer/append/bmesh.types.mod.rst
@@ -18,7 +18,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: list[_GenericType1, ...]
+      :rtype: list[_GenericType1]
       :mod-option rtype: skip-refine
       :option function: overload
 
@@ -45,7 +45,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: list[:class:`BMVert`, ...]
+      :rtype: list[:class:`BMVert`]
       :mod-option rtype: skip-refine
       :option function: overload
 
@@ -72,7 +72,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: list[:class:`BMEdge`, ...]
+      :rtype: list[:class:`BMEdge`]
       :mod-option rtype: skip-refine
       :option function: overload
 
@@ -99,7 +99,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: list[:class:`BMFace`, ...]
+      :rtype: list[:class:`BMFace`]
       :mod-option rtype: skip-refine
       :option function: overload
 
@@ -126,7 +126,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: list[:class:`BMLoop`, ...]
+      :rtype: list[:class:`BMLoop`]
       :mod-option rtype: skip-refine
       :option function: overload
 

--- a/src/mods/common/analyzer/append/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/append/bpy.types.mod.rst
@@ -63,7 +63,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: list[_GenericType1, ...]
+      :rtype: list[_GenericType1]
       :mod-option rtype: skip-refine
       :option function: overload
 
@@ -134,7 +134,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: list[_GenericType1, ...]
+      :rtype: list[_GenericType1]
       :mod-option rtype: skip-refine
       :option function: overload
 
@@ -251,7 +251,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: list[:class:`Material` | None, ...]
+      :rtype: list[:class:`Material` | None]
       :mod-option rtype: skip-refine
       :option function: overload
 


### PR DESCRIPTION
Since it actually accepts just one (probably just a mistake when changing `tuple[xxx, ...]` to `list`).

```python
# too many type arguments provided for "list"; expected 1 but received 2
def test_list() -> list[int, ...]: ...
```
[pyright-play](https://pyright-play.net/?code=MQAgLg9hILYIYDsCe4kAcCmI4CcDmArjBgmAM4ho4QBuAlgCYYMgBmEOIARADZ1lguAbhAYAHpgDGYZiACMIAEYEwIHBkkY6NWQCYAUE1bgMAgPp8BACgCUIALQA%2BEJbABtOqQA0IAHT%2BAXQAuP38gA)