### PR TITLE
Fix: `bpy_prop_array.__getitem__(slice)` to return `tuple`

### DIFF
--- a/src/mods/common/analyzer/new/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/new/bpy.types.mod.rst
@@ -38,7 +38,7 @@
 
       :type key: slice
       :mod-option arg key: skip-refine
-      :rtype: list[_GenericType1, ...]
+      :rtype: tuple[_GenericType1, ...]
       :mod-option rtype: skip-refine
       :option function: overload
 


### PR DESCRIPTION
See example:

```python
from typing import assert_type
import bpy

obj = bpy.context.active_object
assert obj

# <class 'bpy_prop_array'>
print(type(obj.color))
# (1.0, 1.0, 1.0, 1.0)
print(obj.color[:])

# "assert_type" mismatch: expected "tuple[float, ...]" but received "list[float]"
assert_type(obj.color[:], tuple[float, ...])
```