### PR TITLE
Update: Blender 5.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ being too big for intelliSense to work.*
 |4.3|[https://pypi.org/project/fake-bpy-module-4.3/](https://pypi.org/project/fake-bpy-module-4.3/)|
 |4.4|[https://pypi.org/project/fake-bpy-module-4.4/](https://pypi.org/project/fake-bpy-module-4.4/)|
 |4.5|[https://pypi.org/project/fake-bpy-module-4.5/](https://pypi.org/project/fake-bpy-module-4.5/)|
+|5.0|[https://pypi.org/project/fake-bpy-module-5.0/](https://pypi.org/project/fake-bpy-module-5.0/)|
 |latest|[https://pypi.org/project/fake-bpy-module/](https://pypi.org/project/fake-bpy-module/)|
 ||[https://pypi.org/project/fake-bpy-module-latest/](https://pypi.org/project/fake-bpy-module-latest/)|
 

--- a/src/versions.yml
+++ b/src/versions.yml
@@ -23,6 +23,7 @@ SUPPORTED_BLENDER_VERSIONS_BASE:
   - "4.3"
   - "4.4"
   - "4.5"
+  - "5.0"
 
 # Same list, but adding "latest".
 SUPPORTED_BLENDER_VERSIONS:
@@ -49,6 +50,7 @@ SUPPORTED_BLENDER_VERSIONS:
   - "4.3"
   - "4.4"
   - "4.5"
+  - "5.0"
   - "latest"
 
 SUPPORTED_UPBGE_VERSIONS_BASE:
@@ -87,6 +89,7 @@ BLENDER_TAG_NAME:
   "4.3": "v4.3.0"
   "4.4": "v4.4.0"
   "4.5": "v4.5.5"
+  "5.0": "v5.0.0"
   "latest": "main"
 
 UPBGE_TAG_NAME:
@@ -155,6 +158,7 @@ BLENDER_DOWNLOAD_URL_WIN64:
   "4.3": "https://download.blender.org/release/Blender4.3/blender-4.3.0-windows-x64.zip"
   "4.4": "https://download.blender.org/release/Blender4.4/blender-4.4.0-windows-x64.zip"
   "4.5": "https://download.blender.org/release/Blender4.5/blender-4.5.5-windows-x64.zip"
+  "5.0": "https://download.blender.org/release/Blender5.0/blender-5.0.0-windows-x64.zip"
 
 BLENDER_DOWNLOAD_URL_LINUX:
   "2.78": "https://download.blender.org/release/Blender2.78/blender-2.78c-linux-glibc219-x86_64.tar.bz2"
@@ -180,6 +184,7 @@ BLENDER_DOWNLOAD_URL_LINUX:
   "4.3": "https://download.blender.org/release/Blender4.3/blender-4.3.0-linux-x64.tar.xz"
   "4.4": "https://download.blender.org/release/Blender4.4/blender-4.4.0-linux-x64.tar.xz"
   "4.5": "https://download.blender.org/release/Blender4.5/blender-4.5.5-linux-x64.tar.xz"
+  "5.0": "https://download.blender.org/release/Blender5.0/blender-5.0.0-linux-x64.tar.xz"
 # yamllint enable rule:line-length
 
 BLENDER_NEED_MOVE_MACOSX:
@@ -213,6 +218,7 @@ BLENDER_NEED_MOVE_LINUX:
   "4.3": "blender-4.3.0-linux-x64"
   "4.4": "blender-4.4.0-linux-x64"
   "4.5": "blender-4.5.5-linux-x64"
+  "5.0": "blender-5.0.0-linux-x64"
 
 BLENDER_CHECKSUM_URL:
   "2.78": "https://download.blender.org/release/Blender2.78/release278c.md5"
@@ -238,3 +244,4 @@ BLENDER_CHECKSUM_URL:
   "4.3": "https://download.blender.org/release/Blender4.3/blender-4.3.0.md5"
   "4.4": "https://download.blender.org/release/Blender4.4/blender-4.4.0.md5"
   "4.5": "https://download.blender.org/release/Blender4.5/blender-4.5.5.md5"
+  "5.0": "https://download.blender.org/release/Blender5.0/blender-5.0.0.md5"


### PR DESCRIPTION
Including commits from https://github.com/nutti/fake-bpy-module/pull/398 to avoid conflicts on merge.

Requires fixes from https://github.com/nutti/fake-bpy-module/issues/399 to actually work.