### PR TITLE
Fix: `__getitem__` signature for specifying data-block library

### DIFF
--- a/src/mods/common/analyzer/append/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/append/bpy.types.mod.rst
@@ -53,7 +53,7 @@
 
    .. method:: __getitem__(key)
 
-      :type key: int | str | tuple[str | None]
+      :type key: int | str | tuple[str, str | None]
       :mod-option arg key: skip-refine
       :rtype: _GenericType1
       :mod-option rtype: skip-refine


### PR DESCRIPTION
Fixes the last bit of #368, otherwise there's still an issue with the two examples below:

```python
import bpy

# No overloads for "__getitem__" match the provided arguments
obj = bpy.data.objects["xxx", None]
# No overloads for "__getitem__" match the provided arguments
obj = bpy.data.objects["xxx", "filepath.blend"]
```