### PR TITLE
Update: simplify Python version check in .sh files

### DIFF
--- a/src/gen_module.sh
+++ b/src/gen_module.sh
@@ -62,11 +62,12 @@ fi
 python_bin=$(command -v "${PYTHON_BIN}")
 
 echo "Checking if Python version meets the requirements ..."
-IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
-if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 11 ]]; then
-    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.11 or higher."
-    exit 1
-fi
+"$python_bin" -c "
+import sys
+if sys.version_info < (3, 11):
+    print(f'Error: Python 3.11+ required, got {sys.version_info[:3]}')
+    sys.exit(1)
+"
 
 function get_remote_git_ref() {
     local ref=$1

--- a/tests/pylint_cycles.sh
+++ b/tests/pylint_cycles.sh
@@ -79,11 +79,12 @@ fi
 python_bin=$(command -v "${PYTHON_BIN}")
 
 # check if python version meets our requirements
-IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
-if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 11 ]]; then
-    echo "Error: Unsupported Python version \"${python_version[0]}.${python_version[1]}\". Requiring Python 3.11 or higher."
-    exit 1
-fi
+"$python_bin" -c "
+import sys
+if sys.version_info < (3, 11):
+    print(f'Error: Python 3.11+ required, got {sys.version_info[:3]}')
+    sys.exit(1)
+"
 
 function get_remote_git_ref() {
     local ref=$1

--- a/tests/run_pre_tests.sh
+++ b/tests/run_pre_tests.sh
@@ -27,11 +27,12 @@ fi
 python_bin=$(command -v "${PYTHON_BIN}")
 
 # check if python version meets our requirements
-IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
-if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 11 ]]; then
-    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.11 or higher."
-    exit 1
-fi
+"$python_bin" -c "
+import sys
+if sys.version_info < (3, 11):
+    print(f'Error: Python 3.11+ required, got {sys.version_info[:3]}')
+    sys.exit(1)
+"
 
 if ! ${python_bin} "${SCRIPT_DIR}/python/fake_bpy_module_test/run_tests.py" -p "${PACKAGES_PATH}"; then
     echo "Error: fake_bpy_module test failed"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -22,11 +22,12 @@ fi
 python_bin=$(command -v "${PYTHON_BIN}")
 
 # check if python version meets our requirements
-IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
-if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 11 ]]; then
-    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.11 or higher."
-    exit 1
-fi
+"$python_bin" -c "
+import sys
+if sys.version_info < (3, 11):
+    print(f'Error: Python 3.11+ required, got {sys.version_info[:3]}')
+    sys.exit(1)
+"
 
 function check_pep440_compatible_version() {
     local version="${1}"

--- a/tools/pip_package/build_pip_package.sh
+++ b/tools/pip_package/build_pip_package.sh
@@ -57,11 +57,12 @@ fi
 python_bin=$(command -v "${PYTHON_BIN}")
 
 # check if python version meets our requirements
-IFS=" " read -r -a python_version <<< "$(${python_bin} -c 'import sys; print(sys.version_info[:])' | tr -d '(),')"
-if [ "${python_version[0]}" -lt 3 ] || [[ "${python_version[0]}" -eq 3 && "${python_version[1]}" -lt 11 ]]; then
-    echo "Error: Unsupported python version \"${python_version[0]}.${python_version[1]}\". Requiring python 3.11 or higher."
-    exit 1
-fi
+"$python_bin" -c "
+import sys
+if sys.version_info < (3, 11):
+    print(f'Error: Python 3.11+ required, got {sys.version_info[:3]}')
+    sys.exit(1)
+"
 
 if [ "${RELEASE_VERSION:-not_exist}" = "not_exist" ]; then
     echo "Environment variable 'RELEASE_VERSION' does not exist, so use date as release version"


### PR DESCRIPTION
A small change to simplify the check for the used Python version - instead of parsing Python output, we just check version inside Python.