### PR TITLE
Fix: Class bpy_struct does not need generic parameter

### DIFF
--- a/src/mods/common/analyzer/append/bpy.types.mod.rst
+++ b/src/mods/common/analyzer/append/bpy.types.mod.rst
@@ -206,8 +206,6 @@
 
 .. class:: bpy_struct
 
-   :generic-types: _GenericType1
-
    .. attribute:: bl_rna
 
       :type: :class:`bpy.types.BlenderRNA`, (never none)


### PR DESCRIPTION
Fix #435